### PR TITLE
feat: read normalization info from global variable for ServiceX H>ZZ* example

### DIFF
--- a/analyses/atlas-open-data-hzz/CoffeaHZZAnalysisWithServiceX.ipynb
+++ b/analyses/atlas-open-data-hzz/CoffeaHZZAnalysisWithServiceX.ipynb
@@ -49,7 +49,9 @@
     "                                        prefix + 'MC/mc_344235.VBFH125_ZZ4lep.4lep.root',\n",
     "                                        prefix + 'MC/mc_341964.WH125_ZZ4lep.4lep.root',\n",
     "                                        prefix + 'MC/mc_341947.ZH125_ZZ4lep.4lep.root'\n",
-    "                                       ]}"
+    "                                       ]}\n",
+    "\n",
+    "xsec_map = infofile.infos  # dictionary with event weighting information"
    ]
   },
   {
@@ -64,7 +66,7 @@
     "lumi = 10 # fb-1 # data_A,data_B,data_C,data_D\n",
     "\n",
     "def get_xsec_weight(sample):\n",
-    "    info = infofile.infos[sample] # open infofile\n",
+    "    info = xsec_map[sample]\n",
     "    xsec_weight = (lumi*1000*info[\"xsec\"])/(info[\"sumw\"]*info[\"red_eff\"]) #*1000 to go from fb-1 to pb-1\n",
     "    return xsec_weight # return cross-section weight"
    ]
@@ -280,21 +282,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3a366b79f5764116bd99b8319937fd21",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "[root://eospublic.ce...:   0%|          | 0/9000000000.0 [00:00]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "18cb1b096dd54a4b9e4d3defd6b84ae2",
+       "model_id": "",
        "version_major": 2,
        "version_minor": 0
       },
@@ -322,7 +310,21 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e43ec9d1188949fab14976afacc80aab",
+       "model_id": "",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "[root://eospublic.ce...:   0%|          | 0/9000000000.0 [00:00]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "",
        "version_major": 2,
        "version_minor": 0
       },
@@ -335,12 +337,12 @@
     },
     {
      "ename": "Exception",
-     "evalue": "Failure while processing Signal ($m_H$ = 125 GeV)",
+     "evalue": "Failure while processing Background $Z,tt^{bar}$",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m/tmp/ipykernel_425/3909352362.py\u001b[0m in \u001b[0;36mrun_updates_stream\u001b[0;34m(accumulator_stream, name)\u001b[0m\n\u001b[1;32m     30\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 31\u001b[0;31m             \u001b[0;32masync\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mcoffea_info\u001b[0m \u001b[0;32min\u001b[0m \u001b[0maccumulator_stream\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     32\u001b[0m                 \u001b[0;32mpass\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/tmp/ipykernel_7099/3909352362.py\u001b[0m in \u001b[0;36mrun_updates_stream\u001b[0;34m(accumulator_stream, name)\u001b[0m\n\u001b[1;32m     30\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 31\u001b[0;31m             \u001b[0;32masync\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mcoffea_info\u001b[0m \u001b[0;32min\u001b[0m \u001b[0maccumulator_stream\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     32\u001b[0m                 \u001b[0;32mpass\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m/opt/conda/lib/python3.8/site-packages/coffea/processor/servicex/executor.py\u001b[0m in \u001b[0;36mexecute\u001b[0;34m(self, analysis, datasource, title)\u001b[0m\n\u001b[1;32m     82\u001b[0m         \u001b[0;32masync\u001b[0m \u001b[0;32mwith\u001b[0m \u001b[0mfinished_events\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstream\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mstreamer\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 83\u001b[0;31m             \u001b[0;32masync\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mresults\u001b[0m \u001b[0;32min\u001b[0m \u001b[0masync_accumulate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstreamer\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     84\u001b[0m                 \u001b[0;32myield\u001b[0m \u001b[0mresults\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m/opt/conda/lib/python3.8/site-packages/coffea/processor/accumulator.py\u001b[0m in \u001b[0;36masync_accumulate\u001b[0;34m(result_stream)\u001b[0m\n\u001b[1;32m    101\u001b[0m     \u001b[0moutput\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 102\u001b[0;31m     \u001b[0;32masync\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mresults\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mresult_stream\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    103\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0moutput\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m/opt/conda/lib/python3.8/site-packages/aiostream/stream/advanced.py\u001b[0m in \u001b[0;36mbase_combine\u001b[0;34m(source, switch, ordered, task_limit)\u001b[0m\n\u001b[1;32m     58\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 59\u001b[0;31m                 \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtask\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     60\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
@@ -356,10 +358,10 @@
       "\u001b[0;31mTypeError\u001b[0m: Cannot convert OpenFile to pyarrow.lib.NativeFile",
       "\nThe above exception was the direct cause of the following exception:\n",
       "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m/tmp/ipykernel_425/1842051641.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mstart_time\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0moutput\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mawait\u001b[0m \u001b[0mrun_analysis\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0mfinish_time\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/tmp/ipykernel_425/3909352362.py\u001b[0m in \u001b[0;36mrun_analysis\u001b[0;34m()\u001b[0m\n\u001b[1;32m     35\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mcoffea_info\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 37\u001b[0;31m     \u001b[0mall_plots\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mawait\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgather\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrun_updates_stream\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mexecutor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexecute\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0manalysis\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msource\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msource\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmetadata\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'dataset'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0msource\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mdatasources\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     38\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     39\u001b[0m     \u001b[0;31m# Combine the MC plots\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/tmp/ipykernel_425/3909352362.py\u001b[0m in \u001b[0;36mrun_updates_stream\u001b[0;34m(accumulator_stream, name)\u001b[0m\n\u001b[1;32m     32\u001b[0m                 \u001b[0;32mpass\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     33\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mException\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 34\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Failure while processing {name}'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     35\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mcoffea_info\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mException\u001b[0m: Failure while processing Signal ($m_H$ = 125 GeV)"
+      "\u001b[0;32m/tmp/ipykernel_7099/1842051641.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mstart_time\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 4\u001b[0;31m \u001b[0moutput\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mawait\u001b[0m \u001b[0mrun_analysis\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      5\u001b[0m \u001b[0mfinish_time\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mtime\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtime\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/tmp/ipykernel_7099/3909352362.py\u001b[0m in \u001b[0;36mrun_analysis\u001b[0;34m()\u001b[0m\n\u001b[1;32m     35\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mcoffea_info\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 37\u001b[0;31m     \u001b[0mall_plots\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mawait\u001b[0m \u001b[0masyncio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgather\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mrun_updates_stream\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mexecutor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexecute\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0manalysis\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msource\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msource\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmetadata\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'dataset'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0msource\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mdatasources\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     38\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     39\u001b[0m     \u001b[0;31m# Combine the MC plots\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/tmp/ipykernel_7099/3909352362.py\u001b[0m in \u001b[0;36mrun_updates_stream\u001b[0;34m(accumulator_stream, name)\u001b[0m\n\u001b[1;32m     32\u001b[0m                 \u001b[0;32mpass\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     33\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mException\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 34\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mException\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Failure while processing {name}'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     35\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mcoffea_info\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mException\u001b[0m: Failure while processing Background $Z,tt^{bar}$"
      ]
     }
    ],


### PR DESCRIPTION
After this change, #11 happens on coffea-casa.

With `LocalExecutor`, runs into

```
IndexError: list index out of range

The above exception was the direct cause of the following exception:
```

which might be related to https://github.com/ssl-hep/ServiceX_Uproot_Transformer/issues/22.

This change allows to circumvent https://github.com/CoffeaTeam/coffea/issues/601.