### PR TITLE
feat: add ServiceX+coffea option to notebook

### DIFF
--- a/analyses/cms-open-data-ttbar/coffea.ipynb
+++ b/analyses/cms-open-data-ttbar/coffea.ipynb
@@ -1,13 +1,31 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "82f3c55c-3159-4120-9705-e9ffd194b822",
+   "metadata": {},
+   "source": [
+    "### Configuration: number of files and ServiceX usage"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "b547996c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "N_FILES_MAX_PER_SAMPLE = 1  # input files per process, set to -1 for no limit / 1 or 10 for quick debugging  "
+    "# GLOBAL CONFIGURATION\n",
+    "N_FILES_MAX_PER_SAMPLE = 1  # input files per process, set to -1 for no limit / 1 or 10 for quick debugging  \n",
+    "USE_SERVICEX = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e726f38d-e04b-4b1a-8a5f-58f58e2cb329",
+   "metadata": {},
+   "source": [
+    "### Processor"
    ]
   },
   {
@@ -17,15 +35,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import time\n",
+    "import asyncio\n",
+    "\n",
     "import awkward as ak\n",
     "from coffea import processor\n",
+    "from coffea.processor import servicex\n",
     "import hist\n",
     "import json\n",
     "import numpy as np\n",
     "import uproot\n",
     "import cabinetry\n",
+    "from func_adl_servicex import ServiceXSourceUpROOT\n",
+    "from func_adl import ObjectStream\n",
+    "from servicex import ServiceXDataset\n",
+    "from coffea.nanoevents.schemas.base import BaseSchema\n",
     "\n",
-    "class Processor(processor.ProcessorABC):\n",
+    "\n",
+    "processor_base = processor.ProcessorABC if not USE_SERVICEX else servicex.Analysis\n",
+    "\n",
+    "class TtbarAnalysis(processor_base):\n",
     "    def __init__(self):\n",
     "        num_bins = 23\n",
     "        bin_low = 20\n",
@@ -44,7 +73,7 @@
     "\n",
     "        process = events.metadata[\"process\"]  # \"ttbar\" etc.\n",
     "        variation = events.metadata[\"variation\"]  # \"nominal\" etc.\n",
-    "\n",
+    "        \n",
     "        # normalization for MC\n",
     "        x_sec = events.metadata[\"xsec\"]\n",
     "        nevts_total = events.metadata[\"nevts\"]\n",
@@ -80,6 +109,14 @@
     "\n",
     "    def postprocess(self, accumulator):\n",
     "        return accumulator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88b8466e-5010-4a7d-a4cb-b3960942dfbd",
+   "metadata": {},
+   "source": [
+    "### AGC schema (for pure coffea)"
    ]
   },
   {
@@ -129,9 +166,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "f586fab7-16cf-492b-9e00-bf8fb856bf87",
+   "metadata": {},
+   "source": [
+    "### metadata & fileset construction"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "e5b1f8fa",
+   "id": "5feb346b-d158-4438-bc48-f81d18d479f7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,15 +213,147 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "812546fa-850e-4448-b9ee-0544be491aec",
+   "metadata": {},
+   "source": [
+    "### ServiceX-specific functionality: datasource construction, query, asyncio"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "ceab708d-5062-4a13-ba9a-87d762a052e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_datasource(fileset:dict, name: str, query: ObjectStream, ignore_cache: bool):\n",
+    "    \"\"\"Creates a ServiceX datasource for a particular ATLAS Open data file.\"\"\"\n",
+    "    datasets = [ServiceXDataset(fileset[name][\"files\"], backend_name=\"uproot\", ignore_cache=ignore_cache)]\n",
+    "    return servicex.DataSource(\n",
+    "        query=query, metadata=fileset[name][\"metadata\"], datasets=datasets\n",
+    "    )\n",
+    "\n",
+    "def get_query(source: ObjectStream) -> ObjectStream:\n",
+    "    \"\"\"Performs event selection: no filter, select all columns\n",
+    "    \"\"\"\n",
+    "    #return source.Select(lambda e: {\"electron_pt\": e.el_pt, \"electron_eta\": e.el_eta, \"electron_phi\": e.el_phi})\n",
+    "    return source.Select(lambda e: {\n",
+    "                                    \"electron_e\": e.electron_e,\n",
+    "                                    \"electron_pt\": e.electron_pt,\n",
+    "                                    \"electron_px\": e.electron_px,\n",
+    "                                    \"electron_py\": e.electron_py,\n",
+    "                                    \"electron_pz\": e.electron_pz,\n",
+    "                                    \"electron_eta\": e.electron_eta,\n",
+    "                                    \"electron_phi\": e.electron_phi,\n",
+    "                                    \"electron_ch\": e.electron_ch,\n",
+    "                                    \"electron_iso\": e.electron_iso,\n",
+    "                                    \"electron_isLoose\": e.electron_isLoose,\n",
+    "                                    \"electron_isMedium\": e.electron_isMedium,\n",
+    "                                    \"electron_isTight\": e.electron_isTight,\n",
+    "                                    \"electron_dxy\": e.electron_dxy,\n",
+    "                                    \"electron_dz\": e.electron_dz,\n",
+    "                                    \"electron_dxyError\": e.electron_dxyError,\n",
+    "                                    \"electron_dzError\": e.electron_dzError,\n",
+    "\n",
+    "                                    \"numbermuon\": e.numbermuon,\n",
+    "                                    \"muon_e\": e.muon_e,\n",
+    "                                    \"muon_pt\": e.muon_pt,\n",
+    "                                    \"muon_px\": e.muon_px,\n",
+    "                                    \"muon_py\": e.muon_py,\n",
+    "                                    \"muon_pz\": e.muon_pz,\n",
+    "                                    \"muon_eta\": e.muon_eta,\n",
+    "                                    \"muon_phi\": e.muon_phi,\n",
+    "                                    \"muon_ch\": e.muon_ch,\n",
+    "                                    \"muon_isSoft\": e.muon_isSoft,\n",
+    "                                    \"muon_isTight\": e.muon_isTight,\n",
+    "                                    \"muon_dxy\": e.muon_dxy,\n",
+    "                                    \"muon_dz\": e.muon_dz,\n",
+    "                                    \"muon_dxyError\": e.muon_dxyError,\n",
+    "                                    \"muon_dzError\": e.muon_dzError,\n",
+    "                                    \"muon_pfreliso03all\": e.muon_pfreliso03all,\n",
+    "                                    \"muon_pfreliso04all\": e.muon_pfreliso04all,\n",
+    "                                    \"muon_jetidx\": e.muon_jetidx,\n",
+    "                                    \"muon_genpartidx\": e.muon_genpartidx,\n",
+    "\n",
+    "                                    \"jet_e\": e.jet_e,\n",
+    "                                    \"jet_pt\": e.jet_pt,\n",
+    "                                    \"jet_px\": e.jet_px,\n",
+    "                                    \"jet_py\": e.jet_py,\n",
+    "                                    \"jet_pz\": e.jet_pz,\n",
+    "                                    \"jet_eta\": e.jet_eta,\n",
+    "                                    \"jet_phi\": e.jet_phi,\n",
+    "                                    \"jet_ch\": e.jet_ch,\n",
+    "                                    \"jet_mass\": e.jet_mass,\n",
+    "                                    \"jet_btag\": e.jet_btag,\n",
+    "                                    \"jet_pt_uncorr\": e.jet_pt_uncorr,\n",
+    "                                   }\n",
+    ")\n",
+    "\n",
+    "\n",
+    "async def produce_all_histograms(fileset):\n",
+    "    \"\"\"Runs the histogram production, processing input files with ServiceX and\n",
+    "    producing histograms with coffea.\n",
+    "    \"\"\"\n",
+    "    # create the query\n",
+    "    ds = ServiceXSourceUpROOT(\"cernopendata://dummy\", \"events\", backend_name=\"uproot\")\n",
+    "    ds.return_qastle = True\n",
+    "    data_query = get_query(ds)\n",
+    "\n",
+    "    # EXECUTOR: local vs Dask\n",
+    "    executor = servicex.LocalExecutor()\n",
+    "    #executor = servicex.DaskExecutor(client_addr=\"tls://localhost:8786\")\n",
+    "\n",
+    "    datasources = [\n",
+    "        make_datasource(fileset, ds_name, data_query, ignore_cache=False)  # CACHING\n",
+    "        for ds_name in fileset.keys()\n",
+    "    ]\n",
+    "\n",
+    "    # create the analysis processor\n",
+    "    analysis_processor = TtbarAnalysis()\n",
+    "\n",
+    "    async def run_updates_stream(accumulator_stream, name):\n",
+    "        \"\"\"Run to get the last item in the stream\"\"\"\n",
+    "        coffea_info = None\n",
+    "        try:\n",
+    "            async for coffea_info in accumulator_stream:\n",
+    "                pass\n",
+    "        except Exception as e:\n",
+    "            raise Exception(f\"Failure while processing {name}\") from e\n",
+    "        return coffea_info\n",
+    "\n",
+    "    all_histogram_dicts = await asyncio.gather(\n",
+    "        *[\n",
+    "            run_updates_stream(\n",
+    "                executor.execute(analysis_processor, source),\n",
+    "                f\"{source.metadata['process']}__{source.metadata['variation']}\",\n",
+    "            )\n",
+    "            for source in datasources\n",
+    "        ]\n",
+    "    )\n",
+    "    all_histograms = sum([h[\"hist\"] for h in all_histogram_dicts])\n",
+    "    \n",
+    "    return all_histograms"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "757a0a9b-cede-4722-b1d6-98a7f4b779d7",
+   "metadata": {},
+   "source": [
+    "### execute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
    "id": "78fce979",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a5283b2027d84c02ad112c26c7f4d6fb",
+       "model_id": "870cb7dae0ff420397800b2c5ad4776d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -213,7 +390,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e654bbaa4ebc40e199eb5b747ae902bc",
+       "model_id": "98d6605b7dfd41bfabb1da77bf452161",
        "version_major": 2,
        "version_minor": 0
       },
@@ -249,40 +426,64 @@
     }
    ],
    "source": [
-    "USE_DASK = False\n",
+    "if USE_SERVICEX:\n",
+    "    t0 = time.time()\n",
     "\n",
-    "if USE_DASK:\n",
-    "    from dask.distributed import Client\n",
+    "    # in a notebook:\n",
+    "    all_histograms = await produce_all_histograms(fileset)\n",
     "\n",
-    "    client = Client(\"tls://localhost:8786\")\n",
-    "    executor = processor.DaskExecutor(client=client)\n",
+    "    # as a script:\n",
+    "    # async def produce_all_the_histograms(fileset):\n",
+    "    #    return await produce_all_histograms(fileset)\n",
+    "    #\n",
+    "    # all_histograms = asyncio.run(produce_all_the_histograms(fileset))\n",
+    "    \n",
+    "    print(f\"execution took {time.time() - t0:.2f} seconds\")\n",
+    "\n",
     "else:\n",
-    "    executor = processor.IterativeExecutor()\n",
+    "    USE_DASK = False\n",
     "\n",
-    "run = processor.Runner(executor=executor, schema=AGCSchema, savemetrics=True, metadata_cache={})\n",
+    "    if USE_DASK:\n",
+    "        from dask.distributed import Client\n",
     "\n",
-    "all_histograms, metrics = run(fileset, \"events\", processor_instance=Processor())"
+    "        client = Client(\"tls://localhost:8786\")\n",
+    "        executor = processor.DaskExecutor(client=client)\n",
+    "    else:\n",
+    "        executor = processor.IterativeExecutor()\n",
+    "\n",
+    "    run = processor.Runner(executor=executor, schema=AGCSchema, savemetrics=True, metadata_cache={})\n",
+    "\n",
+    "    all_histograms, metrics = run(fileset, \"events\", processor_instance=TtbarAnalysis())\n",
+    "    all_histograms = all_histograms[\"hist\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be8f321a-940a-4e25-86f0-e5889331ad86",
+   "metadata": {},
+   "source": [
+    "### plotting "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "81b41cf4",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x1783b35e0>"
+       "<matplotlib.legend.Legend at 0x7f6cbc39cca0>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaoAAAEkCAYAAAB+NXVeAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAqmElEQVR4nO3de3hU1b3/8fc3CYRLEuQSCBAwVEJgCCImIiiK10KrFfsoilRFjqdYsVr783d+4qXa9jn00VZ6KlWsqFU89QKPtvVWOUVUvHGkAVEggKKgRMIloCQhEEiyfn/MHh2SmVwmIdnJfF7PM8/MfPdee6/ZDn6z1l6zljnnEBER8auEtq6AiIhIfZSoRETE15SoRETE15SoRETE15LaugIiIvFq9erVfZOSkh4FclHDoQZYX1VV9e95eXm7wzcoUYmItJGkpKRHMzIyRqSnp3+VkJAQ10Owa2pqbM+ePYGdO3c+ClwUvi3eM7iISFvKTU9PL433JAWQkJDg0tPT9xNsXR69rQ3qIyIiQQlNTVJTHngnZ8oD7+Qcqwq1Je9a1MlLSlQiInGqpKQk8Z577kkH2Lx5c+c//elPvULb5s+f3/vqq68e3Ha1+5YSlYhInNq7d2/iY4891hfgk08+SV68eHGvhso0VlVVVUsdSolKRCRe3XLLLZnbt29PHj58eGDOnDmZBQUFKcOHDw/86le/6gvw5ZdfdjrjjDOys7Kycm+55Zb+oXLnnXfeCSNHjhwxdOjQkffdd1+fULxbt25jbr755gEnnnji8OXLl6e0VD016k9ExAf+47kPB328s6xb7fiW3eVdw98fPFKdCDDyrqUnhceH9k05WLvssIzUit9dOnp7tHPOmzev6MILL+y6adOmwpdffjl13rx5/d54440tEOz6++ijj7qvW7duQ0pKSs2YMWMCU6ZM2X/mmWdWPPXUU9v69etXXV5ebmPGjAlceeWVX2VkZFQfPHgwITc39+Af/vCHHTFehojUohIRkYgmTJhQmpGRUZ2SkuIuuOCCr958880UgHvvvbdfTk5OIC8vb8TOnTs7bdiwoQtAYmIi11xzzVctXQ+1qEREfKC+lk+40Ii/F346YfOxrRGYWZ33L7/8cuqKFStSCwoKNqWmptaMHTs25+DBgwkAnTt3rklKavm0ohaViEic6tGjR/WBAwcSQq/Ly8sTw7e/8847abt27UosLy+3f/zjH8dNnDix/Ouvv07s0aNHdWpqas0HH3zQ5cMPP+x+rOupFpWISJzKyMiozsvLK8/Ozh555plnliYlJbmcnJzA9OnTS3r27Fmdn59ffvnllw/Ztm1bl0suuWTvmWeeWXHw4MGDCxcuTB82bFjghBNOODR69OgDx7qeSlQiInHspZde2hpt20033bS3dqxr167urbfe+iTS/hUVFR+0ZN1ClKhERNqR1rg35Te6RyUiIr6mRCUiIr6mRCUiIr6mRCUiIr6mRCUi0p4sPDuHhWd3yGU+olGiEhGRiCZOnDi0pKQksb595syZk3Gs66FEJSIiEa1YsWJLnz59quvbZ/78+f3r294SlKhEROLUnXfe2e8///M/+wJce+21g8aNGzcM4IUXXkidMmXKkIEDB44qLi5OAliwYEGvUaNGjRg+fHhg+vTpx1dVVTF79uyBlZWVCcOHDw9cdNFFQ0pLSxPOOuusoTk5OYHs7OyRjzzySM+WqKd+8Csi4gd/v2EQuwvrLPNBycdHLfPBkYpgV9xvBp50VLzPsDrLfNA3UMHFD0ad7Pbss88uv++++/oBu9euXdvt8OHDCZWVlfbWW2+lTJgwoaygoCAFYM2aNV2ee+65XgUFBZuSk5PdlVdeOfhPf/pT7wULFnz5xBNP9N20aVMhwBNPPHFcRkbGkTfffHMLBBdmbNI1iEItKhGRODVhwoSKdevWdf/qq68SkpOTXX5+fvnbb7/dbeXKlannnHNOeWi/pUuXpq5fv77b6NGjRwwfPjzwzjvvpH322WfJtY938sknH3z77bfTrr/++oFLly5N6d27d73dho2lFpWIiB/U0/I5SmjE36w3mj2VUnJyssvMzKx88MEH+4wdO7Z89OjRB1977bXUzz//PHnMmDGHQvs552zq1Kl7H3zwwS/rO96JJ55YuWbNmsLnn3++xx133DHwtddeK73vvvuKm1tPtahEROLYaaedVv7ggw/2O+uss8rOO++8skWLFqUHAoGKhIRv08PkyZNLX3755Z5ffvllEsCuXbsSP/74484ASUlJrrKy0gC2bdvWKTU1tWb27Nn7br755l1r166t25UZA7WoRETi2MSJE8vmz5+fcc455xxIS0urSU5Odqeffvo33X5m5vLy8g7deeedX5577rnDampq6NSpk5s/f/4Xw4YNO/yjH/1oz4gRIwK5ubkVM2bM2HvbbbdlJiQkkJSU5BYsWPB5S9TRnHMtcRwREWmiDz/8cNvo0aNLmlSoBbv+6lNVVUWfPn1O2rVr14fJycmtlig+/PDDPqNHj84Kj6lFJSLSnhzjBBWSnZ098oorrtjTmkkqGiUqERGpY+vWrRvaug4hGkwhIiK+1m5bVH369HFZWVltXQ0RkZj99re/pbCw8PjWPGdlZWXVmDFjPmzNczZXu01UWVlZFBQUtHU1RERitnHjRkaMGNGq51y/fv3hVj1hC1DXn4hIOzJz6UxmLp3Z1tVoVUpUIiLSZGPHjs156623WuQHvQ1RohIREV9TohIRiWONWZrjzjvv7Dds2LBATk5OYPbs2QND8WeeeabnqFGjRmRlZeUuXbo0BWDz5s2d8/LycgKBwIhAIDBi2bJl3QFefvnl1LFjx+ZMnjz5O0OGDBl50UUXDampqWlUHdvtYAoRkY7k3lX3smnfpjrx2rGKqgoAxj89/qj48F7D65Qd3ms4t469td7z/vWvf02rb2mOJUuWpL3yyis9V69evSk1NbVm165d32yvqqqydevWbVy8eHGPX//61wMmT5788YABA6refvvtj7t16+bWrVuXfMUVV3xn/fr1GwE2btzYde3atZ9lZWUdycvLG75s2bKUSZMmldMAtahEROJYQ0tzLFu2LO3KK68sSU1NrQHo16/fN9unTp36FcBpp512oKioqDPA4cOHbfr06VnDhg0LTJ069YRPP/20S2j/UaNGHTjhhBOOJCYmMnLkyIpPP/20c2PqqBaViIgPNNTyCQmN+Ht88uMtct7aS3MsW7as9JVXXukJ8Itf/OJL5xxmFrFsly5dHEBSUhLV1dUGMHfu3H59+/Y98vzzz2+tqamha9eueaH9w6djSkxMpKqqKvKBa1GiEhGJY9u2bevUt2/fqtmzZ+9LTU2tWbRoUe/Qir0QTC5z584d8OMf/3hfqOsvvFVV2/79+xMzMzMPJyYm8sADD/Surm7+2olKVCIicWz16tVd61ua49JLLy1ds2ZNt5NOOmlEp06d3Hnnnbf/gQceiLqA4s0337z7kksuOeHvf/97zwkTJpR17dq1cSMm6tFul/nIz893mpmiYZc/vBKAxdeNb2BPEWltscxM0dyuv/Xr11fk5uZujKlwK9AyHyIi7VxL3ZtqTzTqT0REfE2JSkREfE2JSkREfE2JSkREfE2JSkSkHfn8qqv5/Kqr27oararBRGVmfzaz3Wa2Piz2OzPbZGYfmdnfzOy4sG23mdkWM9tsZpPC4nlmts7bNt+8nzqbWbKZLfbi75tZVst+RGmqyx9e+c2wdhHpuEpKShLvueee9Mbuv3nz5s7Z2dkjj2WdImlMi+oJYHKt2DIg1zl3IvAxcBuAmQWAacBIr8wCMwtNYPgQMAvI9h6hY14LfOWcGwr8F3BvrB+mo1MCEZGWtHfv3sTHHnusb1vXoyENJirn3FvAvlqxfzrnqry3/wtkeq+nAM865yqdc1uBLcBYM+sPpDnnVrrgL4yfBC4OK7PIe/0ccK5Fm1hKRERazC233JK5ffv25OHDhweuu+66zPBt27dvTzr//PNPyMnJCeTk5ARCy3VUV1czbdq044cOHTry9NNPzy4vLzeAefPm9cnNzR2Rk5MTmDRp0gllZWUJAJdccknWNddcM2jMmDHDMzMzRz3++ON1lhFpSEv84PffgMXe64EEE1dIkRc74r2uHQ+V2Q7gnKsys/1Ab6CkBeomItIu7PzNb6jcWHeZj0Objo7VVASX+dh8ytij4l2G113mI3nEcDJuvz3qOefNm1d04YUXdg2f2y/kJz/5yeAzzjij7K677vq0qqqK/fv3J5aUlCR+8cUXXf7yl798dtppp33+/e9//ztPPvlkz9mzZ+/70Y9+9NUtt9xSAnDTTTcNmD9/fp877rhjN8CuXbs6FRQUbFq7dm2XH/7wh0Nnzpz5VcNX5FvNSlRmdgdQBTwVCkXYzdUTr69MpPPNIth9yODBg5tUVxERabz33nsv9bnnntsKwdnRe/fuXV1SUpI4cODAytNOO+0gwJgxYyq2bduWDME5A++6666BZWVliQcOHEicOHHi/tCxLrrooq8TExPJy8s7tHfv3k5NrUvMicrMZgAXAue6bycMLAIGhe2WCezw4pkR4uFliswsCehBra7GEOfcQmAhBOf6i7XuIiJ+U1/LJ1xoxN/x//1ki57/xhtvHLhs2bIeAJFaWCGdO3cOX6rDHTx4MAFg1qxZQ5577rkt48ePPzh//vzeK1asSA3tF1oOBCCW+WVjSlRmNhm4FZjonKsI2/Qi8LSZ/R4YQHDQxCrnXLWZlZnZOOB94Grgj2FlZgArgUuB1117nSm3jfzqpQ0U7iiNuK2wOBiPNAgjMCCNu3/Q6gN4RMQnevToUX3gwIEEgD/+8Y9fAt/Min766aeX/e53v0u/6667dldVVVFaWlrvmIaKioqEwYMHH6msrLRnn322V//+/Y+0VD0bMzz9GYJJJMfMiszsWuABIBVYZmZrzexPAM65DcASoBBYCtzgnAstRnI98CjBARafAq968ceA3ma2Bfg/wJyW+nDxonBH6TcJqdFlikujJjcRiQ8ZGRnVeXl55dnZ2SNrD6Z46KGHvlixYkXqsGHDArm5uYE1a9Z0re9Yc+bM2TF27NgRZ5xxxrDs7OxDLVnPBltUzrkrIoQfq2f/ucDcCPECIDdC/BAwtaF6SP0C/dMiLuURbZkPDXMXEYCXXnppa6T4oEGDqpYvX/5p7fgnn3yyIfT617/+9a7Q61tvvXXPrbfeuqf2/s8///y28PcVFRUfNLWOWuZDRKQdael7U+2BplASERFfU6ISERFfU6ISERFf0z2qOFZYXBpxUEV9Q9pBw9pFpHUpUflMLL+JKiwuJdA/rUnnCQxo2v616yAibeNv89YA8MNbTm7jmrQeJSqfCf0mqimJJ9A/rcmJp74WUbQh7eHbRKT9KykpSXz00Ud7zZkzZ8/5559/wtVXX733qquu+hogKysr97LLLtv729/+thhg0qRJJ0yfPn3vjBkzvm7teipR+VBTfxMlIhKL0DIfc+bM2TNu3Ljyd999N+Wqq676eufOnYndu3evXrVqVffQvh988EH3Rx555PO2qKcSlYhInApf5qNXr15HKisrEwBef/31lO9+97v7X3vttR41NTV8/PHHnZOTk2sGDx5c1dAxjwUlKhERH3h7yceUbC+vEy8pKjvq/ZHK4Kx0j/x8xVHxPpmp1NZnUApnXDYs6jnDl/k4ePCg9e3bd/ShQ4fs3XffTTn77LPLtm7dmvzBBx90WbVqVbf8/Py6lWslGp4uIiJ07drVZWdnH3r33Xe7FRQUdJ84ceKBcePGla9YsSLlvffeSxk/fvyBtqqbWlQiIj5QX8sn3LEc9XfKKaeUv/HGGykHDhxITE9Pr54wYcKB+++/v+/69eu73XjjjXXm8WstSlQdnAZeiEg04ct8AEyYMKH89ttvzxw/fnwZwKmnnlqxZs2a7nv37u2Ul5d3sK3qqa4/EZE4VXuZj3POOae8qKgoedy4cQcAOnXqRO/evatyc3MPJCYmtlk91aISEYljtZf5cM6tDn+/atWqza1bo7qUqERE2pF4mpEiRF1/IiLia0pUIiLia+r6kzo0UlCk9TjnMLO2roYv1NTUGFBTO65E1Y4ogYh0LF26dGHv3r307t077pNVTU2N7dmzpwewvvY2JSoRkTaSmZlJUVERe/a03m9pd+7cmVRdXd2n1U7YeDXA+qqqqn+vvUGJSkSkjXTq1IkhQ4a06jkDgcA651x+q560mTSYQkREfE2JSkREfK3BRGVmfzaz3Wa2PizWy8yWmdkn3nPPsG23mdkWM9tsZpPC4nlmts7bNt+8O4dmlmxmi734+2aW1cKfUURE2rHGtKieACbXis0BljvnsoHl3nvMLABMA0Z6ZRaYWWiCqIeAWUC29wgd81rgK+fcUOC/gHtj/TAiItLxNJionHNvAftqhacAi7zXi4CLw+LPOucqnXNbgS3AWDPrD6Q551Y65xzwZK0yoWM9B5xr8T5OU0REvhHrPap+zrliAO+5rxcfCGwP26/Iiw30XteOH1XGOVcF7Ad6x1gvERHpYFp6MEWklpCrJ15fmboHN5tlZgVmVtCavzsQEZG2E2ui2uV15+E97/biRcCgsP0ygR1ePDNC/KgyZpYE9KBuVyMAzrmFzrl851x+enp6jFUXEZH2JNZE9SIww3s9A3ghLD7NG8k3hOCgiVVe92CZmY3z7j9dXatM6FiXAq9797FEREQanpnCzJ4BzgL6mFkRcDdwD7DEzK4FvgCmAjjnNpjZEqAQqAJucM5Ve4e6nuAIwq7Aq94D4DHgv81sC8GW1LQW+WQiItIhNJionHNXRNl0bpT95wJzI8QLgNwI8UN4iU4a8PgFweeZr7RtPUREWpFmphAREV9TohIREV9TohIREV9TohIREV9TohIREV9TohIREV9TopIWcfnDK7n84ZVtXQ0R6YCUqERExNeUqERExNeUqERExNeUqERExNeUqERExNeUqERExNeUqERExNeUqERExNeUqERExNeUqERExNcaXOFXpLbC4tI60yUVFpcCRJ1GKTAgjbt/MPKY101EOh4lKmmSwIC0JpcJJTERkVgoUUmTRGsVhVpSi68bH3WbiEgsdI9KRER8TYlKRER8TYlKRER8TYlKRER8rVmJysx+bmYbzGy9mT1jZl3MrJeZLTOzT7znnmH732ZmW8xss5lNCovnmdk6b9t8M7Pm1EtERDqOmBOVmQ0EbgLynXO5QCIwDZgDLHfOZQPLvfeYWcDbPhKYDCwws0TvcA8Bs4Bs7zE51nqJiEjH0tyuvySgq5klAd2AHcAUYJG3fRFwsfd6CvCsc67SObcV2AKMNbP+QJpzbqVzzgFPhpUREZE4F3Oics59CdwHfAEUA/udc/8E+jnnir19ioG+XpGBwPawQxR5sYHe69rxOsxslpkVmFnBnj17Yq26iIi0I83p+utJsJU0BBgAdDezK+srEiHm6onXDTq30DmX75zLT09Pb2qVRUSkHWpO1995wFbn3B7n3BHgr8BpwC6vOw/vebe3fxEwKKx8JsGuwiLvde24iIhIs6ZQ+gIYZ2bdgIPAuUABcACYAdzjPb/g7f8i8LSZ/Z5gCywbWOWcqzazMjMbB7wPXA38sRn1kjYQaeokEZGWEHOics69b2bPAWuAKuADYCGQAiwxs2sJJrOp3v4bzGwJUOjtf4Nzrto73PXAE0BX4FXvISIi0rxJaZ1zdwN31wpXEmxdRdp/LjA3QrwAyG1OXUREpGPSzBQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlQiIuJrSlRt4PKHV3L5wyvbuhq+oGshIg1RohIREV9TohIREV9TohIREV9TohIREV9TohIREV9rVqIys+PM7Dkz22RmG81svJn1MrNlZvaJ99wzbP/bzGyLmW02s0lh8TwzW+dtm29m1px6iYhIx9HcFtX9wFLn3HBgNLARmAMsd85lA8u995hZAJgGjAQmAwvMLNE7zkPALCDbe0xuZr1ERKSDiDlRmVkacCbwGIBz7rBz7mtgCrDI220RcLH3egrwrHOu0jm3FdgCjDWz/kCac26lc84BT4aVERGRONecFtV3gD3A42b2gZk9ambdgX7OuWIA77mvt/9AYHtY+SIvNtB7XTsuIiJCUjPLngzc6Jx738zux+vmiyLSfSdXT7zuAcxmEewiZPDgwU2rbRv41UsbKNxRWideWByMRZqRobC4lED/tGNet9ZWWFwa9fNC5GsRGJDG3T8YeczrJiL+1pwWVRFQ5Jx733v/HMHEtcvrzsN73h22/6Cw8pnADi+eGSFeh3NuoXMu3zmXn56e3oyqt47CHaXf/I+4sQL90wgM6FiJKjAgrcnJt7C4NGKSF5H4E3OLyjm308y2m1mOc24zcC5Q6D1mAPd4zy94RV4Enjaz3wMDCA6aWOWcqzazMjMbB7wPXA38MeZP5DOB/mksvm78UbFQ66F2vKOqr1UU7Vpo/j8RCWlO1x/AjcBTZtYZ+AyYSbCVtsTMrgW+AKYCOOc2mNkSgomsCrjBOVftHed64AmgK/Cq9xAREWleonLOrQXyI2w6N8r+c4G5EeIFQG5z6iIiIh2TZqYQERFfU6ISERFfU6ISERFfa+5gCmlpr86Bnesib9v5UfD58QvqbssYBd+759jVS0SkjahF5Tc710VPVC1ZRkSknVCLqg00+PupjFEw85W68VBLqva2SC2sdiJefksmIrFTi0pERHxNiUpERHxNiUpERHxNiUpERHxNiUpERHxNiUpERHxNiUpERHxNiUpERHxNiUpERHxNiUpERHxNiUpERHxNiUpERHxNiUpERHxNiUpaxuMXtOtZ3KUd03evw1OiEhERX1OiEhERX1OiEhERX1OiEhERX2t2ojKzRDP7wMxe9t73MrNlZvaJ99wzbN/bzGyLmW02s0lh8TwzW+dtm29m1tx6iYhIx9ASLaqfARvD3s8BljvnsoHl3nvMLABMA0YCk4EFZpbolXkImAVke4/JLVAv6aAuf3gllz+8sq2rISKtpFmJyswygQuAR8PCU4BF3utFwMVh8Wedc5XOua3AFmCsmfUH0pxzK51zDngyrIyIiMS55rao/gD8P6AmLNbPOVcM4D339eIDge1h+xV5sYHe69pxERGR2BOVmV0I7HbOrW5skQgxV0880jlnmVmBmRXs2bOnkacVEZH2rDktqtOBi8xsG/AscI6Z/QXY5XXn4T3v9vYvAgaFlc8EdnjxzAjxOpxzC51z+c65/PT09GZUXURE2ouYE5Vz7jbnXKZzLovgIInXnXNXAi8CM7zdZgAveK9fBKaZWbKZDSE4aGKV1z1YZmbjvNF+V4eV8T3d2BcRObaSjsEx7wGWmNm1wBfAVADn3AYzWwIUAlXADc65aq/M9cATQFfgVe8hIiLSMonKOfcm8Kb3ei9wbpT95gJzI8QLgNyWqIt0HIXFpRFbq4XFpQARtwUGpHH3D0Ye87qJSOs5Fi0qkWYLDEhrcplQAhORjkWJSnypvlZRqCW1+LrxEeMi0rForj8REfE1JSoREfE1df010q9e2kDhjrr3QOq7sV9YXEqgf9PvtYiIyLfUomqkwh2lTb5ZH+ifFtOgABER+ZZaVE0Q6J8W9QZ+7biIiLQMtahERMTX1KKSdketV5H4ohaViIj4mhKVxAVNHizSfilRiYiIr+keVTPpfomIyLGlRNWezHylrWsgItLq1PUnIiK+pkQlIiK+pq4/6VBiWWwRtOCiiJ8pUUmHEeu8ilpwUcTflKikw4hlscXwbSLiT0pU4R6/IPjclNF1rVUmVqofAHft/Q/v1TvH9DwxXzs/f/f8/pli4ffP1Jr/BtsBJSqRKDYU7wdAd65E2pZG/YmIiK8pUYmIiK8pUYmIiK/FnKjMbJCZvWFmG81sg5n9zIv3MrNlZvaJ99wzrMxtZrbFzDab2aSweJ6ZrfO2zTcza97HEjnayP49GNm/R1tXQ0Ri0JwWVRVwi3NuBDAOuMHMAsAcYLlzLhtY7r3H2zaN4L3pycACM0v0jvUQMAvI9h6Tm1EvERHpQGIe9eecKwaKvddlZrYRGAhMAc7ydlsEvAnc6sWfdc5VAlvNbAsw1sy2AWnOuZUAZvYkcDHwaqx1E2mqSDNa/N/D1YBmsxBpay0yPN3MsoAxwPtAPy+J4ZwrNrO+3m4Dgf8NK1bkxY54r2vHI51nFsGWF4MHD26JqovENKOFZrMQaT3NTlRmlgI8D9zsnCut5/ZSpA2unnjdoHMLgYUA+fn5EfcRaaporaINvwn2TGs2C5G21axRf2bWiWCSeso591cvvMvM+nvb+wO7vXgRMCiseCaww4tnRoiLiIg0a9SfAY8BG51zvw/b9CIww3s9A3ghLD7NzJLNbAjBQROrvG7CMjMb5x3z6rAyIiIS55rT9Xc6cBWwzszWerHbgXuAJWZ2LfAFMBXAObfBzJYAhQRHDN7gnKv2yl0PPAF0JTiIQgMpREQEaN6ov3eIfH8J4NwoZeYCcyPEC4DcWOsiIiIdlyalFYlCPxAW8QdNoSQiIr6mRCUiIr6mRCUiIr6me1TSNK/OgZ3r6sZ3fhR8Dq1MWlvGKPjePceuXu2cFmlsQLTvHei7FweUqKRpdq4LPjJGNa1MnGjNhBNXyS2W712onLR7SlTSdBmjYOYrR8dCf83WjodvE2mOSN870HcvDugelYiI+JpaVCKt5FcvbaBwR+RZ1+tbUkTLiUi8U6ISiVFT17B6f+s+AE4d0qvR53h/6z7e37ovYoLTelkSL5SoRGIQyxpWpw7pFTV5RFtSpL5WWH20XpZ0JEpUIjGIZQ2rljxPQ+eK1sqKq5GC0mFoMIWIiPiaEpWIiPiauv7C+L1b5POrrgbg+P9+so1rItHEOuN6LOUaKtPUwR6gARjiT0pUPvM/b49jX3U/eO/pOtuO1JwDQKcf19p2eAq9EncxaWbd4/2t8DIAftjiNRU/i2WwR7QBGH7/A046PiUqn9lX3Y/STgNIo/GjtvZ1Hco+hlIxb02dbUcqg39B/y3Ctj6DUjjjsmGxV1Z8K5bBHtFaWSJtLe4SVaw/uiwsLiXQv+l/pcYi7cgOrlg0q9H7/2PaL9mfPADIb3SZkqLyGGomItL64i5RFe4ojSnpBPqnNbk75e0lH1OyvW5COPL5JQB02le3lVPaeSBph79s0nlG7n0BgOMXfVB34+O/CD7P/Lejwn+bt4aSovKILa366sfOy+jTfTdnNKmG0l605H0tdRlKS4m7RAXBpBOp66OlfwNTsr2ckqJy+mSmNLpM2uEv6VG5o8nnOrT78DeDLcLVfLYFgITXj96W3HksaSmZQOPrBlBSkd7kuol/1DcAoyXva8VKyU0iictE1VoOf/EFKRUVnLx26VHxms/eByDhq1PrlDn00Wq69O0M/LLR50nu27nJdRvy7oMAdDvllDrb6qvfewkT2FM1sE5LTK2w9i/W+1qRWmHQevMXKrl1fEpUYWIdWhxNTUUFNRUVTfq1Wpe+nZuceDLO6xN8MbPusPXPzx8D1B3SvvM3v6Fy46YmnQeg+9fb4TiA/o0us6NsEDvKBlFUe7Qi4A5dBIBFGOXY6zjHpN/9qMl1lNYTSysslvkL79q7n+6dk8iKqZYtR0mxbShRNdPnTwe76Y6PMDQcIKFbN45/pFYC+Wb9nAi/h2rh9XOOnz4gYjzj9tujF6qvfuePgYoI98Oi3AuD4GCPr6w/pKQ2psoA7EvMYF8ZkUcy1tN600jGllffH3CxTPEUy/yFZYeqKDtUxa1NbLn5JcFJ8/gmUZnZZOB+IBF41Dnnq7Wj/+c/nmLf11Yn7jJ+AsB7EVoLpa4Habb/mNettUW6H3Zo0x4Aurxe9z7ZCRuD3ZnHPxNpsEfkRe/+ce0D7E/ohdd8axSNZPSXaAkuluS27b4uHDhcFbHMv3nd5IEI2yq8JNYUWo7Ff3yRqMwsEXgQOB8oAv5lZi865wpb+lyT33yajD3b+fydul0W0QYeAJQcOY3ylEzSrPF/CabZfnod52KvrA/Fcj8slu7MkYdXcWjTJrocGl5nW7R7aO91mczuj3vxTBO7GCHY8u08ePBRsQkVZQC8E6FVB2q9HQvRkltW7+4ALJ4Z/fdf9Q2QqhOvpwsvlpHB9Q0qUXdh8/kiUQFjgS3Ouc8AzOxZYArQ4okqyWVRkn4i73XpXmdbvq0GoKDL5Drbyrv14rguh7j8/ulHb6hvGewOqL77YVHF0J2ZPKJugmpIj5p9UbedsnU+AAUj7qizraasNPioqDgq/vXGvQAcGlH3Xt6+xAx2fPJ1nZ8fNJTcoomlnB8SabSfYEALf6Z6BuQ0NEq34nB1k4bch5JUxOM+HlxLrHbCbOlBJUpuRzPn2v4vfjO7FJjsnPt37/1VwKnOuZ9GK5Ofn+8KCgqafK7HZjzJoa6ZlKV+Wmfb9C4LAHj60OyIZSu672B71ktHxW4tLgLg3v6Zja5DvWUOH4DO3SFjVKOPx85135Zryrk6Yv1iKHPOa5X03VVTJ35K7m4A/rW+b51th5J/SHlKJoeSj+4O7ur1NB2M/Id8VGdsuR+At4f+rEXKHOqaDUCXg580u371lYl2npY+1zfnOfRZnTIjNywGYMPIy+se0FUDDjj6v1Oy95+7sonTcsfymaKeK/S/3rp3FBqs37WLrmt8BWoxs9XOucbPDuADfklUU4FJtRLVWOfcjbX2mwWEpmzIATa3akVbTx+gpK0r4QO6DkG6DkG6Dt9qzrU43jnXrn4Q6ZeuvyJgUNj7TKDOr16dcwuBha1VqbZiZgXt7S+eY0HXIUjXIUjX4Vvxdi38sh7Vv4BsMxtiZp2BacCLbVwnERHxAV+0qJxzVWb2U+B/CA5P/7NzbkMbV0tERHzAF4kKwDn3D+AfbV0Pn+jw3ZuNpOsQpOsQpOvwrbi6Fr4YTCEiIhKNX+5RiYiIRKRE1cbMbJuZrTOztWZW4MV6mdkyM/vEe+7Z1vU8Fszsz2a228zWh8WifnYzu83MtpjZZjOb1Da1bnlRrsMvzexL73ux1sy+H7ato16HQWb2hpltNLMNZvYzLx5X34l6rkPcfSdC1PXXxsxsG5DvnCsJi/0W2Oecu8fM5gA9nXO3tlUdjxUzOxMoB550zuV6sYif3cwCwDMEZzEZALwGDHPONX0yN5+Jch1+CZQ75+6rtW9Hvg79gf7OuTVmlgqsBi4GriGOvhP1XIfLiLPvRIhaVP40BVjkvV5E8Eva4Tjn3gJqz3sU7bNPAZ51zlU657YCWwj+w2z3olyHaDrydSh2zq3xXpcBG4GBxNl3op7rEE2HvA7hlKjangP+aWarvZk3APo554oh+KUF6s7h03FF++wDge1h+xVR/z/ejuCnZvaR1zUY6u6Ki+tgZlnAGOB94vg7Ues6QJx+J5So2t7pzrmTge8BN3jdQFJXhBnR6Mj91g8BJwAnAcXAPC/e4a+DmaUAzwM3O+fqW66gQ1+LCNchbr8TSlRtzDm3w3veDfyNYJN9l9dPHeqv3t12NWx10T57o6bZ6iicc7ucc9XOuRrgEb7tyunQ18HMOhH8n/NTzrm/euG4+05Eug7x+p0AJao2ZWbdvZulmFl34LvAeoLTR83wdpsBvNA2NWwT0T77i8A0M0s2syFANrCqDerXKkL/Y/b8kOD3AjrwdTAzAx4DNjrnfh+2Ka6+E9GuQzx+J0J8MzNFnOoH/C34vSQJeNo5t9TM/gUsMbNrgS+AqW1Yx2PGzJ4BzgL6mFkRcDdwDxE+u3Nug5ktIbhGWRVwQ0cZ1RTlOpxlZicR7MLZBlwHHfs6AKcDVwHrzGytF7ud+PtORLsOV8ThdwLQ8HQREfE5df2JiIivKVGJiIivKVGJiIivKVGJiIivKVGJiIivKVGJiIivKVGJxMDMrjGzPWb2aFhsrJm96S1HscbMXjGzUfUcI8vMiswsoVZ8rXesn5vZF2b2wLH8LCJ+px/8isRusXPupwBm1g9YAkx3zr3nxSYQnJttXaTCzrltZrYdOANY4ZUZDqQ651YBq8zsKyD/mH8SER9Ti0rintey2WRmj5rZejN7yszOM7N3vdZRY5ZM+CmwKJSkAJxz7zjn/u6dI93Mnjezf3mP073dngGmhR1nmhcTEY8SlUjQUOB+4ERgODAdmAD8X4LT1zRkJLCmnu33A//lnDsFuAQIdRkuAS42s1DvxuXAs02uvUgHpq4/kaCtzrl1AGa2AVjunHNmtg7IaurBzOx9IA34p3PuZ8B5QMCb1xEgzcxSnXM7vfOda2a7gCPOufWRjyoSn5SoRIIqw17XhL2voXH/TjYAJ+PN7O2cO9XMLgUu9LYnAOOdcwcjlA11/+1C3X4idajrT6RlPAhcY2anhcW6hb3+J8H7WAB4s2CHPA98H3X7iUSkFpVIC/C68C4H7jWzgQQX9ysBfu3tchPwoJl9RPDf3VvAT7yyX5vZ/xJccn1r69dexN+0zIdIDMzsGiA/NDy9vZ9HxM/U9ScSm4PA98J/8NvSzOznwG1A6bE6h0h7oBaViIj4mlpUIiLia0pUIiLia0pUIiLia0pUIiLia0pUIiLia/8f+F5delpMHVYAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaoAAAEkCAYAAAB+NXVeAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAgQElEQVR4nO3dfXRU9b3v8fcHovEBYkEC4UELpyIYUIrkUq1WrXqv9GiLd7Ve0FrRYxc9PrS1y9NbaLtqvauepedgH2hBpVrBc63K0vb40OqtUh/vpdj4CImirEIVCRAfakAQDfneP2anDslMIJNJsjP5vNaaNTO/vX97frPXhk9+v/2bvRURmJmZpdWA3m6AmZlZRxxUZmaWag4qMzNLNQeVmZmlWllvN8DMzNp75plnhpeVld0MTKZ/dCpagDXNzc1fnTZt2tbsBQ4qM7MUKisru7mqquqoysrKdwYMGFDy07NbWlrU2NhYvXnz5puBL2Qv6w8pbWbWF02urKxs6g8hBTBgwICorKx8l0wPcs9lvdAeMzPbuwGdDamZv3hqwsxfPDWhuxrU3ZLv2y6XHFRmZtbOm2++OfDaa6+tBFi7du3+N95449DWZQsXLjz0ggsuOLyn2uKgMjOzdt56662Bt9xyy3CAV199tfyuu+4aurc6+6q5ublT6zuozMysnSuvvHLM66+/Xj5x4sTqefPmjamtrR00ceLE6quvvno4wBtvvLHfZz7zmfFjx46dfOWVV45srXf66ad/YtKkSUcdccQRkxYsWDCstfyggw6aesUVV4w65phjJq5YsWJQZ9riWX9mZin37btfOOyVzdsOalu+buv2A7Pf7/xw90CAST946JPZ5UcMH7Szbd0jqwbv+PcvTXk932def/31G88666wDX3755foHHnhg8PXXXz/i0UcfXQeZob8XX3zx4NWrV9cNGjSoZerUqdUzZ85896STTtpx++23bxgxYsTu7du3a+rUqdXnn3/+O1VVVbt37tw5YPLkyTt/+tOfburs93ePyszMOu3EE09sqqqq2j1o0KA488wz33nssccGAVx33XUjJkyYUD1t2rSjNm/evF9dXd0BAAMHDuTCCy98p5DPco/KzCzlOur5ZGud8Xfv5Seu7d4WgaR27x944IHBjz/++ODa2tqXBw8e3DJ9+vQJO3fuHACw//77t5SVFRY57lGZmVk7hxxyyO733ntvQOvr7du3D8xe/tRTT1Vs2bJl4Pbt2/X73//+YyeffPL2v/3tbwMPOeSQ3YMHD2557rnnDnjhhRcOLkZb3KMyM7N2qqqqdk+bNm37+PHjJ5100klNZWVlMWHChOrzzjvvzSFDhuyuqanZPmvWrHEbNmw44Itf/OJbJ5100o6dO3fuXLJkSeWRRx5Z/YlPfOL9KVOmvFeMtjiozMwsp/vvv399vmXf+MY33mpbduCBB8YTTzzxaq71d+zY8Vyh7XBQmZmViJ44N9UbfI7KzMxSzUFlZmap5qAyM7NUc1CZmVmqOajMzErFks9OYMln++xtPvJxUJmZWaedfPLJR7z55psDO1pn3rx5VcX4LAeVmZl12uOPP75u2LBhuztaZ+HChSM7Wr6vHFRmZtbO97///RE/+tGPhgNcfPHFhx133HFHAtx7772DZ86cOW706NFHNzQ0lAEsXrx46NFHH33UxIkTq88777yPNzc3c+mll47etWvXgIkTJ1Z/4QtfGNfU1DTglFNOOWLChAnV48ePn/TLX/5yyL62xT/4NTNLu/+87DC21re7zQdvvrLHbT74cEdmKO5fR39yj/JhR7a7zQfDq3dw9qK8F7v97Gc/u33BggUjgK3PP//8QR988MGAXbt26Yknnhh04oknbqutrR0E8Oyzzx5w9913D62trX25vLw8zj///MNvvPHGQxcvXvzG0qVLh7/88sv1AEuXLv1YVVXVh4899tg6yNyYcV+/vntUZmbWzoknnrhj9erVB7/zzjsDysvLo6amZvuTTz550MqVKwefeuqp21vXe+ihhwavWbPmoClTphw1ceLE6qeeeqriL3/5S3nb7R177LE7n3zyyYpLLrlk9EMPPTTo0EMP7XDYMJt7VGZmaddBz2cPrTP+5j7a5UsplZeXx5gxY3YtWrRo2PTp07dPmTJl5yOPPDL4r3/9a/nUqVPfb10vInTOOee8tWjRojc62t4xxxyz69lnn62/5557Dvne9743+pFHHmlasGBBw760xT0qMzPL6dOf/vT2RYsWjTjllFO2nX766duWLVtWWV1dvWPAgI+iY8aMGU0PPPDAkDfeeKMMYMuWLQNfeeWV/QHKyspi165dAtiwYcN+gwcPbrn00kvfvuKKK7Y8//zz7Ycy83CPyszMcjr55JO3LVy4sOrUU099r6KioqW8vDxOOOGEvw/7SYpp06a9//3vf/+N00477ciWlhb222+/WLhw4WtHHnnkB1/+8pcbjzrqqOrJkyfvmDNnzlvz588fM2DAAMrKymLx4sV/3dd2KCK65xuamVnBXnjhhQ1Tpkx5s1OVijj015Hm5maGDRv2yS1btrxQXl5e1BB54YUXhk2ZMmVsdpl7VGZmpaKbA6rV+PHjJ5177rmNxQ6pfBxUZmbWKevXr6/ryc/zZAozM0u1PtujGjZsWIwdO7a3m2Fm1i2uu+466urqPi6pqNvdtWtX89SpU18o6kaLpKWlRUBL2/I+G1Rjx46ltra2t5thZtYt1q9fz+DBgzn00EMpZlitWbPmg6JtrIhaWlrU2Nh4CLCm7bI+G1RmZqVszJgxbNy4kcbGxqJud/PmzWW7d+8eVtSNFkcLsKa5ufmrbRc4qMzMUmi//fZj3LhxRd9udXX16oioKfqGu5EnU5iZWao5qMzMLNUcVGZmlmoOKjMzSzUHlZmZpZqDyszMUs1BZWZmqeagKnGzblrJrJtW9nYzzMwK5qAyM7NUc1CZmVmqOajMzCzVHFRmZpZqDiozM0s1B5WZmaXaXoNK0q8kbZW0Jqvs3yW9LOlFSb+V9LGsZfMlrZO0VtIZWeXTJK1Oli1UcicwSeWS7krKV0kaW9yvaJ3lKe1mlib70qNaCsxoU/YwMDkijgFeAeYDSKoGZgOTkjqLJQ1M6twAzAXGJ4/WbV4MvBMRRwA/Aa4r9MuUOgeImfVHew2qiHgCeLtN2R8iojl5+ydgTPJ6JnBnROyKiPXAOmC6pJFARUSsjIgAbgPOzqqzLHl9N3CainnfZTMz69OKcY7qn4AHk9ejgdezlm1MykYnr9uW71EnCb93gUOL0C4zMysBXQoqSd8DmoHbW4tyrBYdlHdUJ9fnzZVUK6m2sbGxs801M7M+qOCgkjQHOAv4cjKcB5me0mFZq40BNiXlY3KU71FHUhlwCG2GGltFxJKIqImImsrKykKbbmZmfUhZIZUkzQC+A5wcETuyFt0H/FrSj4FRZCZNPB0RuyVtk3QcsAq4APh5Vp05wErgS8Afs4LP9sHV99dRv6kp57L6hkx5rkkY1aMquOrzk7q1bWZmXbXXoJJ0B3AKMEzSRuAqMrP8yoGHk3kPf4qIf46IOknLgXoyQ4KXRcTuZFOXkJlBeCCZc1qt57VuAf5D0joyPanZxflq/Uf9pibqG5qoHlmx73UacgebmVna7DWoIuLcHMW3dLD+NcA1Ocprgck5yt8HztlbO6xj1SMruOtrx7crb+1JtV3mae5m1lf4yhRmZpZqDiozM0s1B5WZmaWag8rMzFKtoOnpVhrqG5pyTqroaEo7eFq7mfUsB1XKFPKbqM5OTYdM2BTC09rNrKc5qFKmkN9EVY+s6HTwdNQjyjelPXuZmVlPcVClUGd/E2VmVso8mcLMzFLNQWVmZqnmoDIzs1RzUJmZWap5MkWJ88QLM+vr3KMyM7NUc1CZmVmqOajMzCzVHFRmZpZqDiozM0s1z/qzdjxT0MzSxEHVhzhAzKw/8tCfmZmlmoPKzMxSzUFlZmap5qAyM7NU22tQSfqVpK2S1mSVDZX0sKRXk+chWcvmS1onaa2kM7LKp0lanSxbKElJebmku5LyVZLGFvk7mplZH7YvPaqlwIw2ZfOAFRExHliRvEdSNTAbmJTUWSxpYFLnBmAuMD55tG7zYuCdiDgC+AlwXaFfxszMSs9egyoingDeblM8E1iWvF4GnJ1VfmdE7IqI9cA6YLqkkUBFRKyMiABua1OndVt3A6e19rbMzMwKPUc1IiIaAJLn4Un5aOD1rPU2JmWjk9dty/eoExHNwLvAoQW2y8zMSkyxJ1Pk6glFB+Ud1Wm/cWmupFpJtY2NjQU20czM+pJCg2pLMpxH8rw1Kd8IHJa13hhgU1I+Jkf5HnUklQGH0H6oEYCIWBIRNRFRU1lZWWDTzcysLyk0qO4D5iSv5wD3ZpXPTmbyjSMzaeLpZHhwm6TjkvNPF7Sp07qtLwF/TM5jmZmZ7f1af5LuAE4BhknaCFwFXAssl3Qx8BpwDkBE1ElaDtQDzcBlEbE72dQlZGYQHgg8mDwAbgH+Q9I6Mj2p2UX5ZmZmVhL2GlQRcW6eRaflWf8a4Joc5bXA5Bzl75MEne3FrWdmni/6Xe+2w8ysB/nKFGZmlmoOKjMzSzUHlZmZpZqDyszMUs1BZWZmqeagMjOzVHNQWVHMumkls25a2dvNMLMS5KAyM7NUc1CZmVmqOajMzCzVHFRmZpZqDiozM0s1B5WZmaWag8rMzFLNQWVmZqnmoDIzs1RzUJmZWart9Q6/Zm3VNzS1u1xSfUMTQN7LKFWPquCqz0/q9raZWelxUFmnVI+q6HSd1hAzMyuEg8o6JV+vqLUnddfXjs+7zMysED5HZWZmqeagMjOzVHNQmZlZqjmozMws1boUVJK+JalO0hpJd0g6QNJQSQ9LejV5HpK1/nxJ6yStlXRGVvk0SauTZQslqSvtMjOz0lFwUEkaDXwDqImIycBAYDYwD1gREeOBFcl7JFUnyycBM4DFkgYmm7sBmAuMTx4zCm2XmZmVlq4O/ZUBB0oqAw4CNgEzgWXJ8mXA2cnrmcCdEbErItYD64DpkkYCFRGxMiICuC2rjpmZ9XMFB1VEvAEsAF4DGoB3I+IPwIiIaEjWaQCGJ1VGA69nbWJjUjY6ed22vB1JcyXVSqptbGwstOlmZtaHdGXobwiZXtI4YBRwsKTzO6qSoyw6KG9fGLEkImoioqaysrKzTTYzsz6oK0N/pwPrI6IxIj4EfgN8GtiSDOeRPG9N1t8IHJZVfwyZocKNyeu25WZmZl26hNJrwHGSDgJ2AqcBtcB7wBzg2uT53mT9+4BfS/oxmR7YeODpiNgtaZuk44BVwAXAz7vQLusFuS6dZGZWDAUHVUSsknQ38CzQDDwHLAEGAcslXUwmzM5J1q+TtByoT9a/LCJ2J5u7BFgKHAg8mDzMzMy6dlHaiLgKuKpN8S4yvatc618DXJOjvBaY3JW2mJlZafKVKczMLNUcVGZmlmoOKjMzSzUHlZmZpZqDyszMUs1BZWZmqeagMjOzVHNQmZlZqjmozMws1RxUZmaWag4qMzNLNQeVmZmlmoPKzMxSzUFlZmap5qAyM7NUc1CZmVmqOajMzCzVHFS9YNZNK5l108rebkYqeF+Y2d44qMzMLNUcVGZmlmoOKjMzSzUHlZmZpZqDyszMUq1LQSXpY5LulvSypJckHS9pqKSHJb2aPA/JWn++pHWS1ko6I6t8mqTVybKFktSVdpmZWenoao/qZ8BDETERmAK8BMwDVkTEeGBF8h5J1cBsYBIwA1gsaWCynRuAucD45DGji+0yM7MSUXBQSaoATgJuAYiIDyLib8BMYFmy2jLg7OT1TODOiNgVEeuBdcB0SSOBiohYGREB3JZVx8zM+rmu9Kj+AWgEbpX0nKSbJR0MjIiIBoDkeXiy/mjg9az6G5Oy0cnrtuVmZmaUdbHuscDXI2KVpJ+RDPPlkeu8U3RQ3n4D0lwyQ4QcfvjhnWttL7j6/jrqNzW1K69vyJTluiJDfUMT1SMrur1tPa2+oSnv94Xc+6J6VAVXfX5St7fNzNKtKz2qjcDGiFiVvL+bTHBtSYbzSJ63Zq1/WFb9McCmpHxMjvJ2ImJJRNRERE1lZWUXmt4z6jc1/f0/4n1VPbKC6lGlFVTVoyo6Hb71DU05Q97M+p+Ce1QRsVnS65ImRMRa4DSgPnnMAa5Nnu9NqtwH/FrSj4FRZCZNPB0RuyVtk3QcsAq4APh5wd8oZapHVnDX147fo6y199C2vFR11CvKty98/T8za9WVoT+ArwO3S9of+AtwEZle2nJJFwOvAecARESdpOVkgqwZuCwidifbuQRYChwIPJg8zMzMuhZUEfE8UJNj0Wl51r8GuCZHeS0wuSttMTOz0uQrU5iZWao5qMzMLNUcVGZmlmpdnUxhxfbgPNi8OveyzS9mnm89s/2yqqPhc9d2X7vMzHqJe1Rps3l1/qAqZh0zsz7CPapesNffT1UdDRf9rn15a0+q7bJcPaw+or/8lszMCucelZmZpZqDyszMUs1BZWZmqeagMjOzVHNQmZlZqjmozMws1RxUZmaWag4qMzNLNQeVmZmlmoPKzMxSzUFlZmap5qAyM7NUc1CZmVmqOaisOG49s09fxd36MB97Jc9BZWZmqeagMjOzVHNQmZlZqjmozMws1bocVJIGSnpO0gPJ+6GSHpb0avI8JGvd+ZLWSVor6Yys8mmSVifLFkpSV9tlZmaloRg9qm8CL2W9nwesiIjxwIrkPZKqgdnAJGAGsFjSwKTODcBcYHzymFGEdlmJmnXTSmbdtLK3m2FmPaRLQSVpDHAmcHNW8UxgWfJ6GXB2VvmdEbErItYD64DpkkYCFRGxMiICuC2rjpmZ9XNd7VH9FPifQEtW2YiIaABInocn5aOB17PW25iUjU5ety03MzMrPKgknQVsjYhn9rVKjrLooDzXZ86VVCuptrGxcR8/1szM+rKu9KhOAL4gaQNwJ3CqpP8NbEmG80ietybrbwQOy6o/BtiUlI/JUd5ORCyJiJqIqKmsrOxC083MrK8oOKgiYn5EjImIsWQmSfwxIs4H7gPmJKvNAe5NXt8HzJZULmkcmUkTTyfDg9skHZfM9rsgq07q+cS+mVn3KuuGbV4LLJd0MfAacA5ARNRJWg7UA83AZRGxO6lzCbAUOBB4MHmYmZkVJ6gi4jHgseT1W8Bpeda7BrgmR3ktMLkYbbHSUd/QlLO3Wt/QBJBzWfWoCq76/KRub5uZ9Zzu6FGZdVn1qIpO12kNMDMrLQ4qS6WOekWtPam7vnZ8znIzKy2+1p+ZmaWag8rMzFLNQ3/76Or766jf1P4cSEcn9usbmqge2flzLWZm9hH3qPZR/aamTp+srx5ZUdCkADMz+4h7VJ1QPbIi7wn8tuVmZlYc7lGZmVmquUdlfY57r2b9i3tUZmaWag4q6xd88WCzvstBZWZmqeZzVF3k8yVmZt3LQdWXXPS73m6BmVmP89CfmZmlmoPKzMxSzUN/VlIKudki+IaLZmnmoLKSUeh1FX3DRbN0c1BZySjkZovZy8wsnRxU2W49M/Pcmdl1PVWnUG4fAD9469vJq6e69XMK3ndpPvbS/p0Kkfbv1JP/BvsAB5VZHnUN7wLgM1dmvcuz/szMLNUcVGZmlmoOKjMzS7WCg0rSYZIelfSSpDpJ30zKh0p6WNKryfOQrDrzJa2TtFbSGVnl0yStTpYtlKSufS2zPU0aeQiTRh7S280wswJ0pUfVDFwZEUcBxwGXSaoG5gErImI8sCJ5T7JsNplz0zOAxZIGJtu6AZgLjE8eM7rQLjMzKyEFz/qLiAagIXm9TdJLwGhgJnBKstoy4DHgO0n5nRGxC1gvaR0wXdIGoCIiVgJIug04G3iw0LaZdVauK1r8ywe7AV/Nwqy3FWV6uqSxwFRgFTAiCTEiokHS8GS10cCfsqptTMo+TF63Lc/1OXPJ9Lw4/PDDi9F0s4KuaOGrWZj1nC4HlaRBwD3AFRHR1MHppVwLooPy9oURS4AlADU1NTnXMeusfL2iun/NjEz7ahZmvatLs/4k7UcmpG6PiN8kxVskjUyWjwS2JuUbgcOyqo8BNiXlY3KUm5mZdWnWn4BbgJci4sdZi+4D5iSv5wD3ZpXPllQuaRyZSRNPJ8OE2yQdl2zzgqw6ZmbWz3Vl6O8E4CvAaknPJ2XfBa4Flku6GHgNOAcgIuokLQfqycwYvCwidif1LgGWAgeSmUThiRRmZgZ0bdbfU+Q+vwRwWp461wDX5CivBSYX2hYzMytdviitWR7+gbBZOvgSSmZmlmoOKjMzSzUHlZmZpZrPUVnnPDgPNq9uX775xcxz651J26o6Gj53bfe1q4/zTRr3It9xBz72+gEHlXXO5tWZR9XRnavTT/Rk4PSrcCvkuGutZ32eg8o6r+pouOh3e5a1/jXbtjx7mVlX5DruwMdeP+BzVGZmlmruUZn1kKvvr6N+U+6rrnd0SxHfTsT6OweVWYE6ew+rVevfBuBT44bu82esWv82q9a/nTPgfL8s6y8cVGYFKOQeVp8aNzRveOS7pUhHvbCO+H5ZVkocVGYFKOQeVsX8nL19Vr5eVr+aKWglw5MpzMws1RxUZmaWah76y+JhEeuqQq+4Xki9vdXp7GQP8AQMSycHlVkJKmSyR74JGP4Dznqbg8qsBBUy2SNfL8ust/W7oCr0R5f1DU1Uj+z8X6lmZtY1/S6o6jc1FRQ61SMrChpOMetLinley0OGViz9LqggEzq5hj6K/RsYs7TpaAJGMc9rFcrhZrn0y6Ays/YKPa+VqxcGPXf9Qodb6XNQZSl0arFZf1VIL6yQ6xf+4K13OXj/MsYW1MricSj2DgeVmXWooz/gCrnEUyHXL9z2fjPb3m/mO53suaUl4KxrUhNUkmYAPwMGAjdHhO8d3Zfkummd9Wv5Aq6QcNuw4ADe+6A5Z51/4ocAVOdYtiMJsc7w7VjSJxVBJWkgsAj4r8BG4M+S7ouI+t5tmZn1pHzhNvbQgwG466L8v//qaIJUu/IOhvAKmRnc0aQSDxd2XSqCCpgOrIuIvwBIuhOYCTiozKxDe5ulu+OD3Z2act8aUjm3e2vmXmJtA7PYk0ocbntSRPR2G5D0JWBGRHw1ef8V4FMRcXm+OjU1NVFbW9vpz5p100p+8Na3c//ltvnFzHPVMfu+wWLX2bwaqo7u3FDarWd+VK+/t68v1unJz+qr36mQ4w7YsOAUKt97hQ37/cMe5S3vbwdgwAGDctY7eP+yv/fi9qV9G956L+/QZL7P2vZ+Zv3BB7TvL+ytfZO++1TO8n0h6ZmIqCl4A70gLUF1DnBGm6CaHhFfb7PeXGBu8nYCsLZHG9pzhgFv9nYjUsD7IcP7IcP74SNd2Rcfj4jKYjamu6Vl6G8jcFjW+zHAprYrRcQSYElPNaq3SKrta3/xdAfvhwzvhwzvh4/0t32RlvtR/RkYL2mcpP2B2cB9vdwmMzNLgVT0qCKiWdLlwP8hMz39VxFR18vNMjOzFEhFUAFExO+B3/d2O1Ki5Ic395H3Q4b3Q4b3w0f61b5IxWQKMzOzfNJyjsrMzCwnB1Uvk7RB0mpJz0uqTcqGSnpY0qvJ85Debmd3kPQrSVslrckqy/vdJc2XtE7SWkln9E6riy/PfvihpDeS4+J5Sf+YtaxU98Nhkh6V9JKkOknfTMr71THRwX7od8dEKw/99TJJG4CaiHgzq+zfgLcj4lpJ84AhEfGd3mpjd5F0ErAduC0iJidlOb+7pGrgDjJXMRkFPAIcGRGdv5hbyuTZDz8EtkfEgjbrlvJ+GAmMjIhnJQ0GngHOBi6kHx0THeyH/0E/OyZauUeVTjOBZcnrZWQO0pITEU8Ab7cpzvfdZwJ3RsSuiFgPrCPzD7PPy7Mf8inl/dAQEc8mr7cBLwGj6WfHRAf7IZ+S3A/ZHFS9L4A/SHomufIGwIiIaIDMQQsM77XW9bx833008HrWehvp+B9vKbhc0ovJ0GDrcFe/2A+SxgJTgVX042OizX6AfnpMOKh63wkRcSzwOeCyZBjI2lOOslIet74B+ATwSaABuD4pL/n9IGkQcA9wRUR0dOOqkt4XOfZDvz0mHFS9LCI2Jc9bgd+S6bJvScapW8ert/ZeC3tcvu++T5fZKhURsSUidkdEC/BLPhrKKen9IGk/Mv853x4Rv0mK+90xkWs/9NdjAhxUvUrSwcnJUiQdDPw3YA2Zy0fNSVabA9zbOy3sFfm++33AbEnlksYB44Gne6F9PaL1P+bEfydzXEAJ7wdJAm4BXoqIH2ct6lfHRL790B+PiVapuTJFPzUC+G3muKQM+HVEPCTpz8BySRcDrwHn9GIbu42kO4BTgGGSNgJXAdeS47tHRJ2k5WTuUdYMXFYqs5ry7IdTJH2SzBDOBuBrUNr7ATgB+AqwWtLzSdl36X/HRL79cG4/PCYAT083M7OU89CfmZmlmoPKzMxSzUFlZmap5qAyM7NUc1CZmVmqOajMzCzVHFRmBZB0oaRGSTdnlU2X9FhyO4pnJf1O0tEdbGOspI2SBrQpfz7Z1rckvSbpF935XczSzj/4NSvcXRFxOYCkEcBy4LyI+H9J2Ylkrs22OlfliNgg6XXgM8DjSZ2JwOCIeBp4WtI7QE23fxOzFHOPyvq9pGfzsqSbJa2RdLuk0yX936R3tC+3TLgcWNYaUgAR8VRE/GfyGZWS7pH05+RxQrLaHcDsrO3MTsrMLOGgMss4AvgZcAwwETgPOBH4FzKXr9mbScCzHSz/GfCTiPgvwBeB1iHD5cDZklpHN2YBd3a69WYlzEN/ZhnrI2I1gKQ6YEVEhKTVwNjObkzSKqAC+ENEfBM4HahOrusIUCFpcERsTj7vNElbgA8jYk3urZr1Tw4qs4xdWa9bst63sG//TuqAY0mu7B0Rn5L0JeCsZPkA4PiI2Jmjbuvw3xY87GfWjof+zIpjEXChpE9nlR2U9foPZM5jAZBcBbvVPcA/4mE/s5zcozIrgmQIbxZwnaTRZG7u9ybwv5JVvgEskvQimX93TwD/nNT9m6Q/kbnl+vqeb71Zuvk2H2YFkHQhUNM6Pb2vf45Zmnnoz6wwO4HPZf/gt9gkfQuYDzR112eY9QXuUZmZWaq5R2VmZqnmoDIzs1RzUJmZWao5qMzMLNUcVGZmlmr/H1XdR4FGXIutAAAAAElFTkSuQmCC\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
@@ -294,13 +495,13 @@
     }
    ],
    "source": [
-    "all_histograms[\"hist\"][:, \"ttbar\", \"nominal\"].plot(stack=True, label=\"ttbar\")\n",
-    "all_histograms[\"hist\"][:, \"wjets\", \"nominal\"].plot(stack=True, label=\"wjets\")\n",
-    "all_histograms[\"hist\"][:, \"single_top_s_chan\", \"nominal\"].plot(stack=True, label=\"s-chan\")\n",
-    "all_histograms[\"hist\"][:, \"single_top_t_chan\", \"nominal\"].plot(stack=True, label=\"t-chan\")\n",
-    "all_histograms[\"hist\"][:, \"single_top_tW\", \"nominal\"].plot(stack=True, label=\"tW\")\n",
+    "all_histograms[:, \"ttbar\", \"nominal\"].plot(stack=True, label=\"ttbar\")\n",
+    "all_histograms[:, \"wjets\", \"nominal\"].plot(stack=True, label=\"wjets\")\n",
+    "# all_histograms[:, \"single_top_s_chan\", \"nominal\"].plot(stack=True, label=\"s-chan\")\n",
+    "# all_histograms[:, \"single_top_t_chan\", \"nominal\"].plot(stack=True, label=\"t-chan\")\n",
+    "# all_histograms[:, \"single_top_tW\", \"nominal\"].plot(stack=True, label=\"tW\")\n",
     "\n",
-    "#all_histograms[\"hist\"][:, \"data\", \"nominal\"].plot(label=\"data\")\n",
+    "#all_histograms[:, \"data\", \"nominal\"].plot(label=\"data\")\n",
     "\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
@@ -314,17 +515,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "9e796239",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<matplotlib.legend.Legend at 0x1784f4070>"
+       "<matplotlib.legend.Legend at 0x7f6bf1caf790>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -342,11 +543,11 @@
     }
    ],
    "source": [
-    "all_histograms[\"hist\"][:, \"ttbar\", \"nominal\"].plot(label=\"ttbar nominal\")\n",
-    "all_histograms[\"hist\"][:, \"ttbar\", \"ME_var\"].plot(label=\"ttbar ME var\")\n",
-    "all_histograms[\"hist\"][:, \"ttbar\", \"PS_var\"].plot(label=\"ttbar PS var\")\n",
-    "all_histograms[\"hist\"][:, \"ttbar\", \"scaledown\"].plot(label=\"ttbar scale down\")\n",
-    "all_histograms[\"hist\"][:, \"ttbar\", \"scaleup\"].plot(label=\"ttbar scale up\")\n",
+    "all_histograms[:, \"ttbar\", \"nominal\"].plot(label=\"ttbar nominal\")\n",
+    "all_histograms[:, \"ttbar\", \"ME_var\"].plot(label=\"ttbar ME var\")\n",
+    "all_histograms[:, \"ttbar\", \"PS_var\"].plot(label=\"ttbar PS var\")\n",
+    "all_histograms[:, \"ttbar\", \"scaledown\"].plot(label=\"ttbar scale down\")\n",
+    "all_histograms[:, \"ttbar\", \"scaleup\"].plot(label=\"ttbar scale up\")\n",
     "\n",
     "fig = plt.gcf()\n",
     "fig.legend()"
@@ -357,33 +558,33 @@
    "id": "7d2bb804",
    "metadata": {},
    "source": [
-    "## Saving histograms & cabinetry"
+    "### saving histograms & cabinetry"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "804ef793",
    "metadata": {},
    "outputs": [],
    "source": [
     "file_name = \"histograms.root\"\n",
     "with uproot.recreate(file_name) as f:\n",
-    "    f[\"ttbar\"] = all_histograms[\"hist\"][:, \"ttbar\", \"nominal\"]\n",
-    "    f[\"ttbar_ME_var\"] = all_histograms[\"hist\"][:, \"ttbar\", \"ME_var\"]\n",
-    "    f[\"ttbar_PS_var\"] = all_histograms[\"hist\"][:, \"ttbar\", \"PS_var\"]\n",
-    "    f[\"ttbar_scaledown\"] = all_histograms[\"hist\"][:, \"ttbar\", \"scaledown\"]\n",
-    "    f[\"ttbar_scaleup\"] = all_histograms[\"hist\"][:, \"ttbar\", \"scaleup\"]\n",
+    "    f[\"ttbar\"] = all_histograms[:, \"ttbar\", \"nominal\"]\n",
+    "    f[\"ttbar_ME_var\"] = all_histograms[:, \"ttbar\", \"ME_var\"]\n",
+    "    f[\"ttbar_PS_var\"] = all_histograms[:, \"ttbar\", \"PS_var\"]\n",
+    "    f[\"ttbar_scaledown\"] = all_histograms[:, \"ttbar\", \"scaledown\"]\n",
+    "    f[\"ttbar_scaleup\"] = all_histograms[:, \"ttbar\", \"scaleup\"]\n",
     "    \n",
-    "    f[\"wjets\"] = all_histograms[\"hist\"][:, \"wjets\", \"nominal\"]\n",
-    "    f[\"single_top_s_chan\"] = all_histograms[\"hist\"][:, \"single_top_s_chan\", \"nominal\"]\n",
-    "    f[\"single_top_t_chan\"] = all_histograms[\"hist\"][:, \"single_top_t_chan\", \"nominal\"]\n",
-    "    f[\"single_top_tW\"] = all_histograms[\"hist\"][:, \"single_top_tW\", \"nominal\"]"
+    "    f[\"wjets\"] = all_histograms[:, \"wjets\", \"nominal\"]\n",
+    "    f[\"single_top_s_chan\"] = all_histograms[:, \"single_top_s_chan\", \"nominal\"]\n",
+    "    f[\"single_top_t_chan\"] = all_histograms[:, \"single_top_t_chan\", \"nominal\"]\n",
+    "    f[\"single_top_tW\"] = all_histograms[:, \"single_top_tW\", \"nominal\"]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "486ad228",
    "metadata": {},
    "outputs": [
@@ -416,7 +617,7 @@
        "<Figure size 600x200 with 1 Axes>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -437,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "aee58d3d",
    "metadata": {},
    "outputs": [
@@ -446,55 +647,25 @@
      "output_type": "stream",
      "text": [
       "number of files processed: 9\n",
-      "data read: 1.2 GB\n"
+      "data read: 1.2 MB\n"
      ]
     }
    ],
    "source": [
-    "print(f\"number of files processed: {metrics['chunks']}\")\n",
+    "if not USE_SERVICEX:\n",
+    "    print(f\"number of files processed: {metrics['chunks']}\")\n",
+    "    print(f\"data read: {metrics['bytesread']/1024**2:.1f} MB\")\n",
     "\n",
-    "print(f\"data read: {metrics['bytesread']/1024/1024:.1f} GB\")"
+    "    metrics"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "c887fb6a",
+   "execution_count": null,
+   "id": "8cf47522-414f-41f0-b3c2-2fed390469ce",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'bytesread': 1292783,\n",
-       " 'columns': ['jet_py',\n",
-       "  'jet_px',\n",
-       "  'electron_pt',\n",
-       "  'jet_btag',\n",
-       "  'jet_pt_uncorr',\n",
-       "  'numberelectron',\n",
-       "  'jet_ch',\n",
-       "  'jet_pz',\n",
-       "  'muon_pt',\n",
-       "  'numberjet',\n",
-       "  'jet_mass',\n",
-       "  'numbermuon',\n",
-       "  'jet_eta',\n",
-       "  'jet_pt',\n",
-       "  'jet_phi',\n",
-       "  'jet_e'],\n",
-       " 'entries': 391912,\n",
-       " 'processtime': 192.9278862476349,\n",
-       " 'chunks': 9}"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "metrics"
-   ]
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -513,7 +684,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/datasets/cms-open-data-2015/branches.txt
+++ b/datasets/cms-open-data-2015/branches.txt
@@ -39,6 +39,7 @@ jet_ch
 jet_mass
 jet_btag
 jet_pt_uncorr
+
 met_e
 met_pt
 met_px
@@ -84,6 +85,7 @@ photon_phIso
 photon_isLoose
 photon_isMedium
 photon_isTight
+
 PV_chi2
 PV_ndof
 PV_npvs


### PR DESCRIPTION
Updating notebook to have two modes of execution: pure coffea and ServiceX+coffea. The ServiceX auto schema reproduces the AGC schema closely enough so the same processor can be used for both.

related: https://github.com/CoffeaTeam/coffea/issues/664, MET info cannot be easily fed through via ServiceX