### PR TITLE
feat: Add start of pyhf and funcX example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ workshops/agctools2021/HZZ_analysis_pipeline/*/*.npz
 
 # funcX endpoint id
 endpoint_id.txt
+# downloaded pyhf pallets from HEPData
+workshops/agctools2022/statistical-inference/input

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ workshops/agctools2021/HZZ_analysis_pipeline/**/*.root
 workshops/agctools2021/HZZ_analysis_pipeline/*/*.pdf
 workshops/agctools2021/HZZ_analysis_pipeline/*/*.png
 workshops/agctools2021/HZZ_analysis_pipeline/*/*.npz
+
+# funcX endpoint id
+endpoint_id.txt

--- a/workshops/agctools2022/statistical-inference/README.md
+++ b/workshops/agctools2022/statistical-inference/README.md
@@ -6,6 +6,8 @@ TBD
 
 ## Distributed inference with pyhf and funcX
 
+Use pyhf and funcX to perform distributed statistical inference on the probability models of the ATLAS Run 2 search for direct production of electroweakinos [DOI: [10.1140/epjc/s10052-020-8050-3](https://doi.org/10.1140/epjc/s10052-020-8050-3)] [published on HEPData][1Lbb HEPData].
+
 ### Setup
 
 Create a Python virtual environment and install the dependencies defined in `requirements.txt`
@@ -52,3 +54,4 @@ For more information see https://github.com/matthewfeickert/distributed-inferenc
 ## cabinetry overview
 
 [tutorial indico]: https://indico.cern.ch/event/1126109/contributions/4780155/
+[1Lbb HEPData]: https://www.hepdata.net/record/ins1755298

--- a/workshops/agctools2022/statistical-inference/README.md
+++ b/workshops/agctools2022/statistical-inference/README.md
@@ -51,6 +51,13 @@ optional arguments:
                         pyhf backend str alias
 ```
 
+The output of this will be a JSON file `results.json` that contains the inference results for the mass hypotheses used (125 hypotheses in the case of the 1Lbb analysis).
+
+```console
+$ jq length results.json
+125
+```
+
 For more information see https://github.com/matthewfeickert/distributed-inference-with-pyhf-and-funcX
 
 ## cabinetry overview

--- a/workshops/agctools2022/statistical-inference/README.md
+++ b/workshops/agctools2022/statistical-inference/README.md
@@ -58,7 +58,7 @@ $ jq length results.json
 125
 ```
 
-For more information see https://github.com/matthewfeickert/distributed-inference-with-pyhf-and-funcX
+For more information see the [funcX docs][funcx docs] and the [example code][pyhf funcx example code] for the vCHEP 2021 paper "Distributed statistical inference with pyhf enabled through funcX".
 
 ## cabinetry overview
 
@@ -69,4 +69,6 @@ For more information, check out the [cabinetry tutorials][cabinetry tutorial].
 [tutorial indico]: https://indico.cern.ch/event/1126109/contributions/4780155/
 [1Lbb HEPData]: https://www.hepdata.net/record/ins1755298
 [pyhf tutorial]: https://pyhf.github.io/pyhf-tutorial/
+[funcx docs]: https://funcx.readthedocs.io/en/stable/
+[pyhf funcx example code]: https://github.com/matthewfeickert/distributed-inference-with-pyhf-and-funcX
 [cabinetry tutorial]: https://github.com/cabinetry/cabinetry-tutorials

--- a/workshops/agctools2022/statistical-inference/README.md
+++ b/workshops/agctools2022/statistical-inference/README.md
@@ -12,6 +12,7 @@ Create a Python virtual environment and install the dependencies defined in `req
 
 ```console
 $ python -m venv venv
+$ . venv/bin/activate
 $ python -m pip install --upgrade pip setuptools wheel
 $ python -m pip install -r requirements.txt
 ```

--- a/workshops/agctools2022/statistical-inference/README.md
+++ b/workshops/agctools2022/statistical-inference/README.md
@@ -1,8 +1,12 @@
 # [Statistical inference with pyhf and cabinetry][tutorial indico]
 
+## pyhf overview
+
+TBD
+
 ## Distributed inference with pyhf and funcX
 
-## Setup
+### Setup
 
 Create a Python virtual environment and install the dependencies defined in `requirements.txt`
 
@@ -12,7 +16,7 @@ $ python -m pip install --upgrade pip setuptools wheel
 $ python -m pip install -r requirements.txt
 ```
 
-## Run
+### Run
 
 Create a file named `endpoint_id.txt` in the top level of this repository and save your funcX endpoint ID into the file.
 
@@ -43,5 +47,7 @@ optional arguments:
 ```
 
 For more information see https://github.com/matthewfeickert/distributed-inference-with-pyhf-and-funcX
+
+## cabinetry overview
 
 [tutorial indico]: https://indico.cern.ch/event/1126109/contributions/4780155/

--- a/workshops/agctools2022/statistical-inference/README.md
+++ b/workshops/agctools2022/statistical-inference/README.md
@@ -4,6 +4,8 @@
 
 TBD
 
+For more information, check out the [pyhf user's guide and tutorial][pyhf tutorial].
+
 ## Distributed inference with pyhf and funcX
 
 Use pyhf and funcX to perform distributed statistical inference on the probability models of the ATLAS Run 2 search for direct production of electroweakinos [DOI: [10.1140/epjc/s10052-020-8050-3](https://doi.org/10.1140/epjc/s10052-020-8050-3)] [published on HEPData][1Lbb HEPData].
@@ -53,5 +55,11 @@ For more information see https://github.com/matthewfeickert/distributed-inferenc
 
 ## cabinetry overview
 
+TBD
+
+For more information, check out the [cabinetry tutorials][cabinetry tutorial].
+
 [tutorial indico]: https://indico.cern.ch/event/1126109/contributions/4780155/
 [1Lbb HEPData]: https://www.hepdata.net/record/ins1755298
+[pyhf tutorial]: https://pyhf.github.io/pyhf-tutorial/
+[cabinetry tutorial]: https://github.com/cabinetry/cabinetry-tutorials

--- a/workshops/agctools2022/statistical-inference/README.md
+++ b/workshops/agctools2022/statistical-inference/README.md
@@ -1,0 +1,47 @@
+# [Statistical inference with pyhf and cabinetry][tutorial indico]
+
+## Distributed inference with pyhf and funcX
+
+## Setup
+
+Create a Python virtual environment and install the dependencies defined in `requirements.txt`
+
+```console
+$ python -m venv venv
+$ python -m pip install --upgrade pip setuptools wheel
+$ python -m pip install -r requirements.txt
+```
+
+## Run
+
+Create a file named `endpoint_id.txt` in the top level of this repository and save your funcX endpoint ID into the file.
+
+```console
+$ touch endpoint_id.txt
+```
+
+This will be read in during the run.
+
+Pass the config JSON file for the analysis you want to run to `fit_funcx.py`
+
+```
+$ python fit_funcx.py -c config/1Lbb.json -b numpy
+```
+
+```console
+$ python fit_funcx.py --help
+usage: fit_funcx.py [-h] [-c CONFIG_FILE] [-b BACKEND]
+
+configuration arguments provided at run time from the CLI
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -c CONFIG_FILE, --config-file CONFIG_FILE
+                        config file
+  -b BACKEND, --backend BACKEND
+                        pyhf backend str alias
+```
+
+For more information see https://github.com/matthewfeickert/distributed-inference-with-pyhf-and-funcX
+
+[tutorial indico]: https://indico.cern.ch/event/1126109/contributions/4780155/

--- a/workshops/agctools2022/statistical-inference/config/1Lbb.json
+++ b/workshops/agctools2022/statistical-inference/config/1Lbb.json
@@ -1,0 +1,7 @@
+{
+  "input_prefix": "input",
+  "pallet_name": "1Lbb-pallet",
+  "pallet_url": "https://www.hepdata.net/record/resource/1408476?view=true",
+  "analysis_dir": null,
+  "analysis_name": null
+}

--- a/workshops/agctools2022/statistical-inference/fit_funcx.py
+++ b/workshops/agctools2022/statistical-inference/fit_funcx.py
@@ -1,0 +1,155 @@
+import argparse
+import json
+from concurrent.futures import as_completed
+from pathlib import Path
+
+import pyhf
+from funcx import FuncXClient, FuncXExecutor
+from pyhf.contrib.utils import download
+
+
+def prepare_workspace(data, backend):
+    import pyhf
+
+    pyhf.set_backend(backend)
+
+    return pyhf.Workspace(data)
+
+
+def infer_hypotest(workspace, metadata, patches, backend):
+    import time
+
+    import pyhf
+
+    pyhf.set_backend(backend)
+
+    tick = time.time()
+    model = workspace.model(
+        patches=patches,
+        modifier_settings={
+            "normsys": {"interpcode": "code4"},
+            "histosys": {"interpcode": "code4p"},
+        },
+    )
+    data = workspace.data(model)
+    test_poi = 1.0
+    CLs_obs, CLs_exp_band = pyhf.infer.hypotest(
+        test_poi, data, model, return_expected_set=True, test_stat="qtilde"
+    )
+    fit_time = time.time() - tick
+    return {
+        "metadata": metadata,
+        "CLs_obs": float(CLs_obs),
+        "CLs_exp": [float(cls_exp) for cls_exp in CLs_exp_band],
+        "fit_time": fit_time,
+    }
+
+
+def main(args):
+    if args.config_file is not None:
+        with open(args.config_file, "r") as infile:
+            config = json.load(infile)
+
+    backend = args.backend
+
+    pallet_path = Path(config["input_prefix"]).joinpath(config["pallet_name"])
+
+    # locally get pyhf pallet for analysis
+    if not pallet_path.exists():
+        download(config["pallet_url"], pallet_path)
+
+    analysis_name = config["analysis_name"]
+    analysis_prefix_str = "" if analysis_name is None else f"{analysis_name}_"
+    if config["analysis_dir"] is not None:
+        pallet_path = pallet_path.joinpath(config["analysis_dir"])
+
+    with open(
+        pallet_path.joinpath(f"{analysis_prefix_str}BkgOnly.json")
+    ) as bkgonly_json:
+        bkgonly_workspace = json.load(bkgonly_json)
+
+    # Initialize funcX client
+    fxc = FuncXClient()
+    fx = FuncXExecutor(fxc, batch_enabled=True)
+
+    with open("endpoint_id.txt") as endpoint_file:
+        pyhf_endpoint = str(endpoint_file.read().rstrip())
+
+    # execute background only workspace
+    prepare_task_future = fx.submit(
+        prepare_workspace, bkgonly_workspace, backend, endpoint_id=pyhf_endpoint
+    )
+
+    # Read patchset in while background only workspace running
+    with open(
+        pallet_path.joinpath(f"{analysis_prefix_str}patchset.json")
+    ) as patchset_json:
+        patchset = pyhf.PatchSet(json.load(patchset_json))
+
+    workspace = prepare_task_future.result()
+    message = "# Background Workspace Constructed"
+    print("-" * len(message))
+    print(message)
+    print("-" * len(message))
+
+    # execute patch fits across workers and retrieve them when done
+    n_patches = len(patchset.patches)
+    futures = []
+    results = {}
+    for patch_idx in range(n_patches):
+        patch = patchset.patches[patch_idx]
+        futures.append(
+            fx.submit(
+                infer_hypotest,
+                workspace,
+                patch.metadata,
+                [patch.patch],
+                backend,
+                endpoint_id=pyhf_endpoint,
+            )
+        )
+
+    for task in as_completed(futures):
+        task_result = task.result()
+        results[task_result["metadata"]["name"]] = {
+            "mass_hypotheses": task_result["metadata"]["values"],
+            "CLs_obs": task_result["CLs_obs"],
+            "CLs_exp": task_result["CLs_exp"],
+            "fit_time": task_result["fit_time"],
+        }
+        print(
+            f'{task_result["metadata"]["name"]}: {results[task_result["metadata"]["name"]]}'
+        )
+
+    print("-" * len(message))
+
+    with open("results.json", "w") as results_file:
+        results_file.write(json.dumps(results, sort_keys=True, indent=2))
+
+
+if __name__ == "__main__":
+    cli_parser = argparse.ArgumentParser(
+        description="configuration arguments provided at run time from the CLI"
+    )
+    cli_parser.add_argument(
+        "-c",
+        "--config-file",
+        dest="config_file",
+        type=str,
+        default=None,
+        help="config file",
+    )
+    cli_parser.add_argument(
+        "-b",
+        "--backend",
+        dest="backend",
+        type=str,
+        default="numpy",
+        help="pyhf backend str alias",
+    )
+    args, unknown = cli_parser.parse_known_args()
+
+    parser = argparse.ArgumentParser(parents=[cli_parser], add_help=False)
+    args = parser.parse_args()
+
+    main(args)

--- a/workshops/agctools2022/statistical-inference/requirements.txt
+++ b/workshops/agctools2022/statistical-inference/requirements.txt
@@ -1,0 +1,13 @@
+# pyhf
+pyhf[contrib]==0.6.3
+# cabinetry
+cabinetry==0.4.1
+# funcx
+funcx==0.3.9
+funcx-endpoint==0.3.9
+# jax
+jax==0.3.7
+# Place --find-links _before_ jaxlib to satisfy Conda
+--find-links https://storage.googleapis.com/jax-releases/jax_releases.html
+jaxlib==0.3.7
+

--- a/workshops/agctools2022/statistical-inference/requirements.txt
+++ b/workshops/agctools2022/statistical-inference/requirements.txt
@@ -10,4 +10,3 @@ jax==0.3.7
 # Place --find-links _before_ jaxlib to satisfy Conda
 --find-links https://storage.googleapis.com/jax-releases/jax_releases.html
 jaxlib==0.3.7
-


### PR DESCRIPTION
Resolves #33

This PR ports [an example](https://github.com/matthewfeickert/distributed-inference-with-pyhf-and-funcX) application of distributed inference with pyhf + funcX that can be demoed. This PR by itself should fulfill Issue #33 and will provide the input files for planned follow up PRs to add plotting of exclusion contour plots.

Additionally add stubs for pyhf and cabinetry tutorial sections that have yet to be written.

**Squash and merge commit message**
```
* Add pyhf + funcX example of distributed statistical inference for the published ATLAS
1Lbb SUSY analysis.
   - c.f. https://www.hepdata.net/record/ins1755298
* Add requirements.txt for pyhf, cabinetry, and funcX
* Add pyhf and funcX related files to gitignore
* Add README with information and stubs for pyhf and funcX sections of the statistical
inference tutorial.
```