### PR TITLE
feat: Use cabinetry tutorials but with ATLAS 139ifb 1Lbb workspace

### DIFF
--- a/workshops/agctools2022/statistical-inference/README.md
+++ b/workshops/agctools2022/statistical-inference/README.md
@@ -62,9 +62,10 @@ For more information see the [funcX docs][funcx docs] and the [example code][pyh
 
 ## cabinetry overview
 
-TBD
+Given time, most of the section on cabinetry will be focused on following the [cabinetry tutorials][cabinetry tutorial].
+Though to tie into the `pyhf` + `funcX` demonstration, the `cabinetry-HEPData-workspace.ipynb` notebook will be using the same HEPData workspace.
 
-For more information, check out the [cabinetry tutorials][cabinetry tutorial].
+For more information on cabinetry, check out the [cabinetry docs][cabinetry docs].
 
 [tutorial indico]: https://indico.cern.ch/event/1126109/contributions/4780155/
 [1Lbb HEPData]: https://www.hepdata.net/record/ins1755298
@@ -72,3 +73,4 @@ For more information, check out the [cabinetry tutorials][cabinetry tutorial].
 [funcx docs]: https://funcx.readthedocs.io/en/stable/
 [pyhf funcx example code]: https://github.com/matthewfeickert/distributed-inference-with-pyhf-and-funcX
 [cabinetry tutorial]: https://github.com/cabinetry/cabinetry-tutorials
+[cabinetry docs]: https://cabinetry.readthedocs.io/en/stable/

--- a/workshops/agctools2022/statistical-inference/cabinetry-HEPData-workspace.ipynb
+++ b/workshops/agctools2022/statistical-inference/cabinetry-HEPData-workspace.ipynb
@@ -1,6 +1,20 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using cabinetry to interact with published models from HEPData"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook is a variation on the [`cabinetry` tutorials](https://github.com/cabinetry/cabinetry-tutorials) created by [Alexander Held](https://github.com/alexander-held)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -29,7 +43,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Download a workspace from HEPData, extract it, pick a signal with `pyhf`. We use a workspace from an ATLAS search for bottom-squark pair production: [JHEP 12 (2019) 060](https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/SUSY-2018-31/). The corresponding HEPData entry is [10.17182/hepdata.89408.v3](https://doi.org/10.17182/hepdata.89408.v3)."
+    "Download a workspace from HEPData, extract it, pick a signal with `pyhf`. We use the same models that we used with `pyhf` and `funcX` from an ATLAS search for electroweakinos in final states with one lepton, missing transverse momentum and a Higgs boson decaying into two b-jets : [Eur. Phys. J. C 80 (2020) 691](https://inspirehep.net/literature/1755298). The corresponding HEPData entry is [ins1755298](https://www.hepdata.net/record/ins1755298)."
    ]
   },
   {
@@ -39,21 +53,10 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "import pyhf\n",
-    "from pyhf.contrib.utils import download\n",
+    "from pathlib import Path\n",
     "\n",
-    "download(\"https://www.hepdata.net/record/resource/1935437?view=true\", \"bottom-squarks\")\n",
-    "ws = pyhf.Workspace(json.load(open(\"bottom-squarks/RegionC/BkgOnly.json\")))\n",
-    "patchset = pyhf.PatchSet(json.load(open(\"bottom-squarks/RegionC/patchset.json\")))\n",
-    "ws = patchset.apply(ws, \"sbottom_600_280_150\")\n",
-    "cabinetry.workspace.save(ws, \"bottom-squarks.json\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The `bottom-squarks.json` workspace is now ready to be used. We will run a maximum likelihood fit with `cabinetry` and visualize the results. First, we have a brief look at the content of the workspace:"
+    "import pyhf\n",
+    "from pyhf.contrib.utils import download"
    ]
   },
   {
@@ -62,7 +65,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pyhf inspect bottom-squarks.json | head -n 6"
+    "# locally get pyhf pallet for analysis\n",
+    "probability_models_url_1Lbb = (\n",
+    "    \"https://www.hepdata.net/record/resource/1934827?view=true\"\n",
+    ")\n",
+    "pallet_path = Path().cwd() / \"input\" / \"1Lbb-pallet\"\n",
+    "\n",
+    "if not pallet_path.exists():\n",
+    "    download(probability_models_url_1Lbb, pallet_path)\n",
+    "\n",
+    "with open(pallet_path / \"BkgOnly.json\") as read_file:\n",
+    "    workspace = pyhf.Workspace(json.load(read_file))\n",
+    "\n",
+    "with open(pallet_path / \"patchset.json\") as read_file:\n",
+    "    patchset = pyhf.PatchSet(json.load(read_file))\n",
+    "\n",
+    "workspace = patchset.apply(workspace, \"C1N2_Wh_hbb_800_300\")\n",
+    "cabinetry.workspace.save(workspace, \"1Lbb.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `1Lbb.json` workspace is now ready to be used. We will run a maximum likelihood fit with `cabinetry` and visualize the results. First, we have a brief look at the content of the workspace:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pyhf inspect 1Lbb.json | head -n 6"
    ]
   },
   {
@@ -81,8 +116,8 @@
    },
    "outputs": [],
    "source": [
-    "ws = cabinetry.workspace.load(\"bottom-squarks.json\")\n",
-    "model, data = cabinetry.model_utils.model_and_data(ws)"
+    "workspace = cabinetry.workspace.load(\"1Lbb.json\")\n",
+    "model, data = cabinetry.model_utils.model_and_data(workspace)"
    ]
   },
   {
@@ -106,7 +141,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also visualize the pre-fit model prediction and compare it to data. the `visualize.data_mc` function returns a list of dictionaries containing the `matplotlib` figures, which we could use to customize them as needed. We do not need to customize anything here, so we assign the return value to `_`."
+    "We can also visualize the pre-fit model prediction and compare it to data. the `visualize.data_mc` function returns a list of dictionaries containing the `matplotlib` figures, which we could use to customize them as needed. We do not need to customize anything here."
    ]
   },
   {
@@ -115,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_ = cabinetry.visualize.data_mc(model_prefit, data)"
+    "cabinetry.visualize.data_mc(model_prefit, data);"
    ]
   },
   {
@@ -148,7 +183,7 @@
    "outputs": [],
    "source": [
     "model_postfit = cabinetry.model_utils.prediction(model, fit_results=fit_results)\n",
-    "_ = cabinetry.visualize.data_mc(model_postfit, data)"
+    "cabinetry.visualize.data_mc(model_postfit, data);"
    ]
   },
   {

--- a/workshops/agctools2022/statistical-inference/cabinetry-HEPData-workspace.ipynb
+++ b/workshops/agctools2022/statistical-inference/cabinetry-HEPData-workspace.ipynb
@@ -1,0 +1,201 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cabinetry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We customize the output from `cabinetry` via a helper function. This is optional, and the `logging` module can be used directly as well to further customize the behavior."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cabinetry.set_logging()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download a workspace from HEPData, extract it, pick a signal with `pyhf`. We use a workspace from an ATLAS search for bottom-squark pair production: [JHEP 12 (2019) 060](https://atlas.web.cern.ch/Atlas/GROUPS/PHYSICS/PAPERS/SUSY-2018-31/). The corresponding HEPData entry is [10.17182/hepdata.89408.v3](https://doi.org/10.17182/hepdata.89408.v3)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import pyhf\n",
+    "from pyhf.contrib.utils import download\n",
+    "\n",
+    "download(\"https://www.hepdata.net/record/resource/1935437?view=true\", \"bottom-squarks\")\n",
+    "ws = pyhf.Workspace(json.load(open(\"bottom-squarks/RegionC/BkgOnly.json\")))\n",
+    "patchset = pyhf.PatchSet(json.load(open(\"bottom-squarks/RegionC/patchset.json\")))\n",
+    "ws = patchset.apply(ws, \"sbottom_600_280_150\")\n",
+    "cabinetry.workspace.save(ws, \"bottom-squarks.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `bottom-squarks.json` workspace is now ready to be used. We will run a maximum likelihood fit with `cabinetry` and visualize the results. First, we have a brief look at the content of the workspace:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pyhf inspect bottom-squarks.json | head -n 6"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The fit model specified in the workspace is created next."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true,
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ws = cabinetry.workspace.load(\"bottom-squarks.json\")\n",
+    "model, data = cabinetry.model_utils.model_and_data(ws)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can take a look at a yield table for this model. We first generate the pre-fit model prediction, and then pass it to a function to produce a yield table from it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_prefit = cabinetry.model_utils.prediction(model)\n",
+    "cabinetry.tabulate.yields(model_prefit, data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also visualize the pre-fit model prediction and compare it to data. the `visualize.data_mc` function returns a list of dictionaries containing the `matplotlib` figures, which we could use to customize them as needed. We do not need to customize anything here, so we assign the return value to `_`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = cabinetry.visualize.data_mc(model_prefit, data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next up is a maximum likelihood fit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fit_results = cabinetry.fit.fit(model, data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now visualize the post-fit distributions. To do so, we need a post-fit model prediction. It is obtained like the pre-fit model prediction, but this time with an additional argument to pass in the fit results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_postfit = cabinetry.model_utils.prediction(model, fit_results=fit_results)\n",
+    "_ = cabinetry.visualize.data_mc(model_postfit, data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The nuisance parameter pulls and correlations are visualized below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cabinetry.visualize.pulls(fit_results, exclude=\"mu_SIG\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cabinetry.visualize.correlation_matrix(fit_results, pruning_threshold=0.2)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
```
* Note in statistical-inference README that the cabinetry tutorials will be used
to cover material efficiently.
* Copy HEPData_workspace.ipynb from cabinetry tutorial but use the HEPData workspace used for
pyhf + funcX demonstration.
   - c.f. https://www.hepdata.net/record/ins1755298
```