### PR TITLE
fix: Use requests over curl for greater portability

### DIFF
--- a/workshops/agctools2022/statistical-inference/plot-contour.ipynb
+++ b/workshops/agctools2022/statistical-inference/plot-contour.ipynb
@@ -513,13 +513,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2da2d78-e8be-4d2b-b1dd-1a9f96ff7fbf",
+   "id": "62fc8994-f92a-4b95-8b18-3a89903c52be",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Exploit GitHub CDN ![arXiv_figure_6](https://user-images.githubusercontent.com/5142394/165033580-ed1104f3-5548-47af-8226-6d9469a79267.png)\n",
-    "! mkdir -p figures\n",
-    "! curl -sL https://user-images.githubusercontent.com/5142394/165033580-ed1104f3-5548-47af-8226-6d9469a79267.png --output figures/arxiv_1909.09226_figure_6.png"
+    "# Download the published plot from where it has been stored on GitHub's CDN\n",
+    "figure_path = pathlib.Path(\"figures\") / \"arxiv_1909.09226_figure_6.png\"\n",
+    "if not figure_path.is_file():\n",
+    "    figure_path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    # Exploit GitHub CDN\n",
+    "    response = requests.get(\"https://user-images.githubusercontent.com/5142394/165033580-ed1104f3-5548-47af-8226-6d9469a79267.png\")\n",
+    "    response.raise_for_status()\n",
+    "    figure_path.write_bytes(response.content)"
    ]
   },
   {
@@ -533,7 +538,7 @@
     "plot_exclusions(results, ax1)\n",
     "ax1.legend(loc=(0.05, 0.6))\n",
     "\n",
-    "img = plt.imread(\"figures/arxiv_1909.09226_figure_6.png\")\n",
+    "img = plt.imread(figure_path)\n",
     "ax2.imshow(img, aspect=\"auto\")\n",
     "ax2.axis(\"off\")\n",
     "\n",

--- a/workshops/agctools2022/statistical-inference/plot-contour.ipynb
+++ b/workshops/agctools2022/statistical-inference/plot-contour.ipynb
@@ -522,7 +522,9 @@
     "if not figure_path.is_file():\n",
     "    figure_path.parent.mkdir(parents=True, exist_ok=True)\n",
     "    # Exploit GitHub CDN\n",
-    "    response = requests.get(\"https://user-images.githubusercontent.com/5142394/165033580-ed1104f3-5548-47af-8226-6d9469a79267.png\")\n",
+    "    response = requests.get(\n",
+    "        \"https://user-images.githubusercontent.com/5142394/165033580-ed1104f3-5548-47af-8226-6d9469a79267.png\"\n",
+    "    )\n",
     "    response.raise_for_status()\n",
     "    figure_path.write_bytes(response.content)"
    ]


### PR DESCRIPTION
```
* Use requests to download the published plot figure as coffea-casa doesn't have
curl available to the users by default.
```