### PR TITLE
Use `vector` in the HZZAnalysis notebook

### DIFF
--- a/analyses/atlas-open-data-hzz/CoffeaHZZAnalysisWithServiceX.ipynb
+++ b/analyses/atlas-open-data-hzz/CoffeaHZZAnalysisWithServiceX.ipynb
@@ -26,6 +26,7 @@
     "import hist\n",
     "import re\n",
     "import matplotlib.pyplot as plt\n",
+    "import vector\n",
     "%matplotlib inline\n",
     "\n",
     "import infofile # Same infofile used in https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata"
@@ -99,26 +100,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def calc_mllll(lep_pt,lep_eta,lep_phi,lep_E):\n",
-    "    # TODO: use vector here\n",
-    "    # first lepton is [0], 2nd lepton is [1] etc\n",
-    "    px_0 = lep_pt[:,0]*np.cos(lep_phi[:,0]) # x-component of lep[0] momentum\n",
-    "    py_0 = lep_pt[:,0]*np.sin(lep_phi[:,0]) # y-component of lep[0] momentum\n",
-    "    pz_0 = lep_pt[:,0]*np.sinh(lep_eta[:,0]) # z-component of lep[0] momentum\n",
-    "    px_1 = lep_pt[:,1]*np.cos(lep_phi[:,1]) # x-component of lep[1] momentum\n",
-    "    py_1 = lep_pt[:,1]*np.sin(lep_phi[:,1]) # y-component of lep[1] momentum\n",
-    "    pz_1 = lep_pt[:,1]*np.sinh(lep_eta[:,1]) # z-component of lep[1] momentum\n",
-    "    px_2 = lep_pt[:,2]*np.cos(lep_phi[:,2]) # x-component of lep[2] momentum\n",
-    "    py_2 = lep_pt[:,2]*np.sin(lep_phi[:,2]) # y-component of lep[2] momentum\n",
-    "    pz_2 = lep_pt[:,2]*np.sinh(lep_eta[:,2]) # z-component of lep[3] momentum\n",
-    "    px_3 = lep_pt[:,3]*np.cos(lep_phi[:,3]) # x-component of lep[3] momentum\n",
-    "    py_3 = lep_pt[:,3]*np.sin(lep_phi[:,3]) # y-component of lep[3] momentum\n",
-    "    pz_3 = lep_pt[:,3]*np.sinh(lep_eta[:,3]) # z-component of lep[3] momentum\n",
-    "    sumpx = px_0 + px_1 + px_2 + px_3 # x-component of 4-lepton momentum\n",
-    "    sumpy = py_0 + py_1 + py_2 + py_3 # y-component of 4-lepton momentum\n",
-    "    sumpz = pz_0 + pz_1 + pz_2 + pz_3 # z-component of 4-lepton momentum\n",
-    "    sumE = lep_E[:,0] + lep_E[:,1] + lep_E[:,2] + lep_E[:,3] # energy of 4-lepton system\n",
-    "    return np.sqrt(sumE**2 - sumpx**2 - sumpy**2 - sumpz**2)/1000 #/1000 to go from MeV to GeV"
+    "def calc_mllll(lep_pt, lep_eta, lep_phi, lep_E):\n",
+    "    # construct awkward 4-vector array\n",
+    "    p4 = vector.zip({\"pt\": lep_pt, \"eta\": lep_eta, \"phi\": lep_phi, \"E\": lep_E})\n",
+    "    # calculate invariant mass of first 4 leptons\n",
+    "    # [:, i] selects the i-th lepton in each event\n",
+    "    # .M calculates the invariant mass\n",
+    "    return (p4[:, 0] + p4[:, 1] + p4[:, 2] + p4[:, 3]).M / 1000 #/1000 to go from MeV to GeV"
    ]
   },
   {
@@ -630,7 +618,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The notebook now uses `vector` in the `calc_mllll` function. I wasn't able to run the notebook locally because of an error, but I am hoping that the function is correct. The function has been taken up from [this](https://github.com/atlas-outreach-data-tools/notebooks-collection-opendata/blob/master/13-TeV-examples/uproot_python/HZZAnalysis.ipynb) notebook. 

---

The error that I getting while running the notebook -

```
ServiceXException: (ServiceXException(...), 'Unable to find name/type uproot in api_endpoints in servicex.yaml configuration file. Saw only names (default, default) and types (xaod, cms_run1_aod)')
```

Full stack trace:

<details>
<summary>Trace:</summary>

```console
---------------------------------------------------------------------------
ServiceXException                         Traceback (most recent call last)
Input In [10], in <cell line: 4>()
      1 import time
      3 start_time = time.time()
----> 4 output = await run_analysis()
      5 finish_time = time.time()
      7 print("Total runtime in seconds: " + str(finish_time - start_time))

Input In [9], in run_analysis()
      6 ds_names = list(fileset.keys())
      8 # Create the query
----> 9 ds = ServiceXSourceUpROOT('cernopendata://dummy',  'mini', backend_name='uproot')
     10 ds.return_qastle = True
     11 leptons = good_leptons(ds)

File c:\users\saransh\saransh_softwares\python_3.9\lib\site-packages\func_adl_servicex\ServiceX.py:207, in ServiceXSourceUpROOT.__init__(self, sx, treename, backend_name)
    203 def __init__(self, sx: Union[ServiceXDataset, DatasetType], treename: str, backend_name='uproot'):
    204     '''
    205     Create a servicex dataset sequence from a servicex dataset
    206     '''
--> 207     super().__init__(sx, backend_name)
    209     # Modify the argument list in EventDataSset to include a dummy filename and
    210     # tree name
    211     self.query_ast.args.append(ast.Str(s='bogus.root'))  # type: ignore

File c:\users\saransh\saransh_softwares\python_3.9\lib\site-packages\func_adl_servicex\ServiceX.py:57, in ServiceXDatasetSourceBase.__init__(self, sx, backend_name)
     55 # Get the base created
     56 if isinstance(sx, (str, Iterable)):
---> 57     ds = ServiceXDataset(sx, backend_name=backend_name)
     58 else:
     59     ds = sx

File c:\users\saransh\saransh_softwares\python_3.9\lib\site-packages\servicex\servicex.py:270, in ServiceXDataset.__init__(self, dataset, backend_name, image, max_workers, result_destination, servicex_adaptor, minio_adaptor, cache_adaptor, status_callback_factory, local_log, session_generator, config_adaptor, data_convert_adaptor, ignore_cache)
    256 self._cache = (
    257     Cache(
    258         get_configured_cache_path(config.settings),
   (...)
    265     else cache_adaptor
    266 )
    268 if not servicex_adaptor:
    269     # Given servicex adaptor is none, this should be ok. Fixes type checkers
--> 270     end_point, token = config.get_servicex_adaptor_config(backend_name)
    271     servicex_adaptor = ServiceXAdaptor(end_point, token)
    272 self._servicex_adaptor = servicex_adaptor

File c:\users\saransh\saransh_softwares\python_3.9\lib\site-packages\servicex\servicex_config.py:196, in ServiceXConfigAdaptor.get_servicex_adaptor_config(self, backend_name)
    183 def get_servicex_adaptor_config(
    184     self, backend_name: Optional[str] = None
    185 ) -> Tuple[str, Optional[str]]:
    186     """Return the servicex (endpoint, token) from a given backend configuration.
    187 
    188     Args:
   (...)
    194         token (optionally).
    195     """
--> 196     config = self._get_backend_info(backend_name)
    198     endpoint = config["endpoint"]
    199     token = config["token"] if "token" in config else None

File c:\users\saransh\saransh_softwares\python_3.9\lib\site-packages\servicex\servicex_config.py:136, in ServiceXConfigAdaptor._get_backend_info(self, backend_name)
    125         seen_types = [
    126             str(ep["type"].as_str_expanded())
    127             for ep in endpoints
    128             if ep["type"].exists()
    129         ]
    130         seen_names = [
    131             str(ep["name"].as_str_expanded())
    132             for ep in endpoints
    133             if ep["name"].exists()
    134         ]
--> 136         raise ServiceXException(
    137             f"Unable to find name/type {backend_name} "
    138             "in api_endpoints in servicex.yaml configuration file. Saw"
    139             f' only names ({", ".join(seen_names)}) and types '
    140             f'({", ".join(seen_types)})'
    141         )
    143 # Nope - now we are going to have to just use the first one there.
    144 else:
    145     for ep in endpoints:

ServiceXException: (ServiceXException(...), 'Unable to find name/type uproot in api_endpoints in servicex.yaml configuration file. Saw only names (default, default) and types (xaod, cms_run1_aod)')
```

</details>