### PR TITLE
docs: add Zenodo DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Analysis Grand Challenge (AGC)
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7274936.svg)](https://doi.org/10.5281/zenodo.7274936)
+
 The Analysis Grand Challenge (AGC) is about performing the last steps in an analysis pipeline at scale to test workflows envisioned for the HL-LHC.
 This includes
 


### PR DESCRIPTION
With the first tag, we now have a Zenodo DOI: https://doi.org/10.5281/zenodo.7274936. Adding this to the readme.