### PR TITLE
docs: add notebooks used for AGC-2023 workshop

### DIFF
--- a/workshops/agctools2023/MLFlowExample.ipynb
+++ b/workshops/agctools2023/MLFlowExample.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd94a310-05df-45ce-b77b-c6b57cc461f0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import mlflow\n",
+    "from mlflow.models.signature import infer_signature\n",
+    "import xgboost as xgb\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a71b183-f5bf-4a90-8f78-6a5c8802e501",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['MLFLOW_TRACKING_TOKEN'] = '' #set token\n",
+    "os.environ['MLFLOW_TRACKING_URI'] = \"https://mlflow-demo.software-dev.ncsa.illinois.edu\"\n",
+    "\n",
+    "mlflow.set_tracking_uri('https://mlflow-demo.software-dev.ncsa.illinois.edu') \n",
+    "mlflow.set_experiment(\"test-experiment\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f3cf34a-bcad-45dc-a4bc-db0dfff41bc6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "train_data = np.concatenate((np.random.randn(10000,10), 2*np.random.randn(10000,10)+2))\n",
+    "train_labels = np.concatenate((np.ones(10000), np.zeros(10000)))\n",
+    "\n",
+    "test_data = np.concatenate((np.random.randn(100,10), 2*np.random.randn(100,10)+2))\n",
+    "test_labels = np.concatenate((np.ones(100), np.zeros(100)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8611ff53-6576-41a8-8628-f13da9d84687",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "params = {\n",
+    "    'reg_lambda': 1,\n",
+    "    'reg_alpha': 0.5,\n",
+    "    'n_estimators': 5,\n",
+    "    'min_child_weight': 379,\n",
+    "    'max_depth': 10,\n",
+    "    'learning_rate': 0.5,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0b9cff96-cf8e-48b0-8835-3471f72febbb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with mlflow.start_run(run_name=\"MY_RUN\") as run:\n",
+    "    \n",
+    "    # log params\n",
+    "    for param_name, value in params.items():\n",
+    "        mlflow.log_param(param_name, value)\n",
+    "\n",
+    "    # train model\n",
+    "    model = xgb.XGBClassifier(nthread=-1, **params)\n",
+    "    model.fit(train_data, train_labels)\n",
+    "    \n",
+    "    # log metrics\n",
+    "    mlflow.log_metric('train_score', model.score(train_data, train_labels))\n",
+    "    mlflow.log_metric('test_score', model.score(test_data, test_labels))\n",
+    "    \n",
+    "    # log model\n",
+    "    signature = infer_signature(test_data, model.predict(test_data))\n",
+    "    mlflow.xgboost.log_model(model, \"model\", signature=signature)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/workshops/agctools2023/TritonExample.ipynb
+++ b/workshops/agctools2023/TritonExample.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5eae4a7f-20b6-418d-bf60-46a64f4befc2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import tritonclient.grpc as grpcclient\n",
+    "\n",
+    "triton_client = grpcclient.InferenceServerClient(url=\"agc-triton-inference-server:8001\")\n",
+    "model_metadata = triton_client.get_model_metadata(\"reconstruction_bdt_xgb\", \"1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "345f3abd-406e-447d-8c2a-6795965202e8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "model_metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af4a61ab-b478-4c53-8c68-f9ea14c028b0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_name = model_metadata.inputs[0].name\n",
+    "dtype = model_metadata.inputs[0].datatype\n",
+    "output_name = model_metadata.outputs[0].name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd77252b-3ce3-4066-a74c-e4cfb7069ef0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "output = grpcclient.InferRequestedOutput(output_name)\n",
+    "\n",
+    "# generate random feature set\n",
+    "import numpy as np\n",
+    "features = np.random.randn(10000,20).astype(np.float32)\n",
+    "\n",
+    "# set inputs\n",
+    "inpt = [grpcclient.InferInput(input_name, features.shape, dtype)]\n",
+    "inpt[0].set_data_from_numpy(features)\n",
+    "\n",
+    "# perform inference request\n",
+    "results = triton_client.infer(model_name=\"reconstruction_bdt_xgb\",\n",
+    "                              model_version=\"2\",\n",
+    "                              inputs=inpt,\n",
+    "                              outputs=[output]).as_numpy(output_name)[:, 1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "07be8aee-b9d5-4c0f-a728-39494c4ecb39",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "results[0:10]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/workshops/agctools2023/correctionlib_demo.ipynb
+++ b/workshops/agctools2023/correctionlib_demo.ipynb
@@ -1,0 +1,421 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c0cf00b-0d05-4659-872b-5c4bf16d0c3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import correctionlib\n",
+    "import correctionlib.schemav2 as cs\n",
+    "import numpy as np\n",
+    "import rich\n",
+    "\n",
+    "np.set_printoptions(precision=3,floatmode='fixed')\n",
+    "\n",
+    "# Initialize some dummy data\n",
+    "sz = 5\n",
+    "event_number = np.random.randint(max(sz,123456), max(sz*100,1234567), size=sz)\n",
+    "jet_pt = np.random.exponential(scale=10, size=sz) + np.random.exponential(scale=15.0, size=sz)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a81ed72-5b4d-4524-8a45-a88aa125b895",
+   "metadata": {},
+   "source": [
+    "### Example 1\n",
+    "\n",
+    "Every correction we want to use will be constructed/instantiated as a `Correction` object that all go into a `CorrectionSet` for later lookup in your event processor. Here we create a super basic correction that is just always a flat value. The only input variable here (`\"some shape array\"`) is used to let `correctionlib` infer the shape of the output array it should return."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56dd5c16-d72b-4b6c-9918-baa93a9bf86f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flat_correction = cs.Correction(\n",
+    "    name=\"flat correction\",\n",
+    "    version=1,\n",
+    "    inputs=[\n",
+    "        # Doesn't affect the weights, but does define the shape of the output array\n",
+    "        cs.Variable(name=\"some shape array\", type=\"real\", description=\"Placeholder input to control shape of output array\"),\n",
+    "    ],\n",
+    "    output=cs.Variable(name=\"weight\", type=\"real\"),\n",
+    "    data=1.03\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7d8b2f9-623f-4971-bce0-f1943c785e3f",
+   "metadata": {},
+   "source": [
+    "Usage of this correction might look like:\n",
+    "```python\n",
+    "output = evaluator[\"flat correction\"].evaluate(some_pt_array)\n",
+    "```\n",
+    "This would look functionally equivalent to something like:\n",
+    "```python\n",
+    "output = numpy.full_like(some_pt_array,1.03,dtype='float')\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b902fdcf-45ee-4b36-965b-efc59138d2fb",
+   "metadata": {},
+   "source": [
+    "### Example 2\n",
+    "\n",
+    "Very similar to the first example, but now we use a `Category`, instead of a single `float`, to create named bins to switch between different variations of a particular correction. This lends itself very naturally to computing systematic up/down variations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aadc184a-940a-4e08-ad9d-a02a43b9ccc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flat_variation = cs.Correction(\n",
+    "    name=\"flat variation\",\n",
+    "    version=1,\n",
+    "    inputs=[\n",
+    "        # Again, this first input is simply to determine the shape of the generated output array\n",
+    "        cs.Variable(name=\"shape\", type=\"real\", description=\"Placeholder input to control shape of output array\"),\n",
+    "\n",
+    "        # This input will determine which variation we want to use and so will affect the array contents\n",
+    "        cs.Variable(name=\"direction\", type=\"string\"),\n",
+    "    ],\n",
+    "    output=cs.Variable(name=\"weight\", type=\"real\"),\n",
+    "    data=cs.Category(\n",
+    "        nodetype=\"category\",\n",
+    "        input=\"direction\",\n",
+    "        content=[\n",
+    "            cs.CategoryItem(key=\"up\",value=1.0 + 0.03),\n",
+    "            cs.CategoryItem(key=\"down\",value=1.0 - 0.03),\n",
+    "        ],\n",
+    "        default=1.0,    # Value to use when no key is matched, useful for 'nominal' variations\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffec3a73-5720-473a-b8de-25e748f5e702",
+   "metadata": {},
+   "source": [
+    "### Example 3\n",
+    "\n",
+    "Now for an example using more dynamic correction. As before we use the `Category` object in order to define up/down bins, but now the returned value is defined using the `cs.Formula` class. This class lets us define a `TFormula` expression that computes an output based on some per-element input array, e.g. object pt. Instead of a `TFormula`, could just as easily swap it for a `correctionlb` `Binning` or `MultiBinning` object to make use of `pt`,`eta`,`BDT` output, etc. binned corrections/variations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37717583-8e9f-44ce-9b75-31749bc447c6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "variable_variation = cs.Correction(\n",
+    "    name=\"variable variation\",\n",
+    "    version=1,\n",
+    "    inputs=[\n",
+    "        # We don't need a placeholder 'shape' input, since correctionlib can infer the shape from our inputs this time\n",
+    "        cs.Variable(name=\"obj pt\", type=\"real\"),\n",
+    "        cs.Variable(name=\"direction\", type=\"string\")\n",
+    "    ],\n",
+    "    output=cs.Variable(name=\"weight\", type=\"real\"),\n",
+    "    data=cs.Category(\n",
+    "        nodetype=\"category\",\n",
+    "        input=\"direction\",\n",
+    "        content=[\n",
+    "            cs.CategoryItem(\n",
+    "                key=\"up\",\n",
+    "                value=cs.Formula(\n",
+    "                    nodetype=\"formula\",\n",
+    "                    parser=\"TFormula\",\n",
+    "                    variables=[\"obj pt\"],\n",
+    "                    expression=\"1.0 + (x*0.075 / 50)\"\n",
+    "                )\n",
+    "            ),\n",
+    "            cs.CategoryItem(\n",
+    "                key=\"down\",\n",
+    "                value=cs.Formula(\n",
+    "                    nodetype=\"formula\",\n",
+    "                    parser=\"TFormula\",\n",
+    "                    variables=[\"obj pt\"],\n",
+    "                    expression=\"1.0 - (x*0.075 / 50)\"\n",
+    "                )\n",
+    "            )\n",
+    "        ],\n",
+    "        default=1.0\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "010ddd39-fe2b-497c-b5a1-aed8cfe653b0",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Putting it all together\n",
+    "\n",
+    "We collect all of our corrections together into a `CorrectionSet` object, that is what we feed our inputs into and get a corresponding correction array with a shape that matches the input array shape."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1426fb7-b4fb-4c33-b674-80f0da5426e1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "simple_cset = cs.CorrectionSet(\n",
+    "    schema_version=2,\n",
+    "    corrections=[\n",
+    "        flat_correction,\n",
+    "        flat_variation,\n",
+    "        variable_variation\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a566221-5c89-4a06-a38e-b97d801adefa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rich.print(simple_cset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec6326a0-a84a-496c-b84b-c0ec392554d4",
+   "metadata": {},
+   "source": [
+    "### Saving Corrections\n",
+    "\n",
+    "Now to save our corrections to a `JSON` file for later use by us or some colleague. Accomplished simply via `CorrectionSet.json()` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c3a37d6-b018-4e33-a114-c528d667536e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"demo_corrections.json\", \"w\") as fout:\n",
+    "    fout.write(simple_cset.json(exclude_unset=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14ec8a43-c8ff-4dd3-a3d2-0d1d6681955a",
+   "metadata": {},
+   "source": [
+    "### Loading Corrections\n",
+    "\n",
+    "We can then use this `JSON` file to insantiate our `CorrectionSet` object directly.\n",
+    "\n",
+    "**Note:** When loading from a file, the code automatically converts the `CorrectionSet` to an evaluator. If we instead wanted to use the `simple_cset` object we constructed earlier directly, we would need to something like `ceval = simple_cset.to_evaluator()` before proceeding."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf9597c7-04b9-4430-ab67-7a688566046e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ceval = correctionlib.CorrectionSet.from_file(\"demo_corrections.json\")\n",
+    "print(f\"flat correction -- {ceval['flat correction'].evaluate(jet_pt)}\")\n",
+    "for syst in ['flat variation', 'variable variation']:\n",
+    "    for d in ['up', 'nominal', 'down']:\n",
+    "        print(f\"{syst} -- {d:<7}: {ceval[syst].evaluate(jet_pt,d)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab0b00a0-4aed-4dde-b5e7-4e3ed1783845",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "with open(\"demo_corrections.json\", \"r\") as fin:\n",
+    "    j = json.load(fin)\n",
+    "    print(json.dumps(j,indent=4))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87f25fef-0323-4291-9df4-57fc7b4b3b3e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Alternate `CorrectionSet` Structure\n",
+    "\n",
+    "The nestable nature of the `Correction` objects makes `correctionlib` very flexible. Here we show how we can put each of the above correction examples into individual `CategoryItem` objects that are grouped together under a single overarching `Correction`, which might correspond to some more abstract class of corrections, e.g. all of the jet systematics, or all of the pt/eta binned systematics, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "416d1f5a-aae4-4507-b8b9-1f9f50fdacfb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Note: Need to be a bit careful here and make sure that all Variable names are internally consistent\n",
+    "#       within the Correction object. To make this easier, we can simply insantiate the Variable objects\n",
+    "#       directly and re-use them where needed\n",
+    "syst_name_variable = cs.Variable(name=\"systematic name\", type=\"string\", description=\"Name of systematic\")\n",
+    "direction_variable = cs.Variable(name=\"direction\", type=\"string\", description=\"Direction of the variation\")\n",
+    "jet_pt_variable = cs.Variable(name=\"pt\", type=\"real\", description=\"The pt of the jets\")\n",
+    "output_variable = cs.Variable(name=\"weight\", type=\"real\")\n",
+    "\n",
+    "# Example 1\n",
+    "jet_pt_scale = cs.CategoryItem(\n",
+    "    key=\"flat correction\",\n",
+    "    value=1.03\n",
+    ")\n",
+    "\n",
+    "# Example 2\n",
+    "jet_pt_variation = cs.CategoryItem(\n",
+    "    key=\"flat variation\",\n",
+    "    value=cs.Category(\n",
+    "        nodetype=\"category\",\n",
+    "        input=direction_variable.name,\n",
+    "        content=[\n",
+    "            cs.CategoryItem(key=\"up\", value=1.0 + 0.03),\n",
+    "            cs.CategoryItem(key=\"down\", value=1.0 - 0.03)\n",
+    "        ],\n",
+    "        default=1.0\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "# Example 3\n",
+    "jet_pt_formula_up = cs.Formula(\n",
+    "    nodetype=\"formula\",\n",
+    "    parser=\"TFormula\",\n",
+    "    variables=[jet_pt_variable.name],\n",
+    "    expression=\"1.0 + (x*0.075 / 50)\"\n",
+    ")\n",
+    "jet_pt_formula_down = cs.Formula(\n",
+    "    nodetype=\"formula\",\n",
+    "    parser=\"TFormula\",\n",
+    "    variables=[jet_pt_variable.name],\n",
+    "    expression=\"1.0 - (x*0.075 / 50)\"\n",
+    ")\n",
+    "jet_pt_variable_variation = cs.CategoryItem(\n",
+    "    key=\"variable variation\",\n",
+    "    value=cs.Category(\n",
+    "        nodetype=\"category\",\n",
+    "        input=direction_variable.name,\n",
+    "        content=[\n",
+    "            cs.CategoryItem(key=\"up\", value=jet_pt_formula_up),\n",
+    "            cs.CategoryItem(key=\"down\", value=jet_pt_formula_down)\n",
+    "        ],\n",
+    "        default=1.0\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb5ac5f2-0000-4e6b-a2eb-e4bf7e8e5b05",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Putting it all together\n",
+    "jet_systs = cs.Correction(\n",
+    "    name=\"jet systematics\",\n",
+    "    version=1,\n",
+    "    inputs=[\n",
+    "        syst_name_variable,\n",
+    "        direction_variable,\n",
+    "        jet_pt_variable\n",
+    "    ],\n",
+    "    output=output_variable,\n",
+    "    data=cs.Category(\n",
+    "        nodetype=\"category\",\n",
+    "        input=syst_name_variable.name,\n",
+    "        content=[\n",
+    "            jet_pt_variation,\n",
+    "            jet_pt_scale,\n",
+    "            jet_pt_variable_variation\n",
+    "        ],\n",
+    "        default=1.0\n",
+    "    )\n",
+    ")\n",
+    "compact_cset = cs.CorrectionSet(\n",
+    "    schema_version=2,\n",
+    "    corrections=[\n",
+    "        jet_systs\n",
+    "    ]\n",
+    ")\n",
+    "rich.print(compact_cset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77d5c7ad-5500-45fa-ab4b-55a8dfc8d100",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "compact_ceval = compact_cset.to_evaluator()\n",
+    "print(f\"flat correction -- {compact_ceval['jet systematics'].evaluate('flat correction','nominal',jet_pt)}\")\n",
+    "for syst in ['flat variation', 'variable variation']:\n",
+    "    for d in ['up','nominal','down']:\n",
+    "        print(f\"{syst} -- {d:<7}: {compact_ceval['jet systematics'].evaluate(syst,d,jet_pt)}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR introduces the Jupyter notebooks that were showcased for the 2023 AGC workshop in May. The workbooks were all committed in their un-evaluated state.

Indico link: [IRIS-HEP AGC workshop 2023](https://indico.cern.ch/event/1260431/timetable/?view=standard)