### PR TITLE
docs: update links for RDF implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ We believe that the AGC can be useful in various contexts:
 We are very interested in seeing (parts of) the AGC implemented in different ways!
 Besides the implementation in this repository, have a look at
 
-- a ROOT RDataFrame-based implementation: [andriiknu/RDF/](https://github.com/andriiknu/RDF/),
+- a ROOT RDataFrame-based implementation: [root-project/analysis-grand-challenge](https://github.com/root-project/analysis-grand-challenge),
 - a pure Julia implementation: [Moelf/LHC_AGC.jl](https://github.com/Moelf/LHC_AGC.jl).
 
 Please get in touch if you have investigated other approaches you would like to share!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ We believe that the AGC can be useful in various contexts:
 We are very interested in seeing (parts of) the AGC implemented in different ways!
 Besides the implementation in this repository, have a look at
 
-* a ROOT RDataFrame-based implementation: `andriiknu/RDF/ <https://github.com/andriiknu/RDF/>`_
+* a ROOT RDataFrame-based implementation: `root-project/analysis-grand-challenge <https://github.com/root-project/analysis-grand-challenge>`_
 * a pure Julia implementation: `Moelf/LHC_AGC.jl <https://github.com/Moelf/LHC_AGC.jl>`_
 
 Please get in touch if you have investigated other approaches you would like to share!


### PR DESCRIPTION
Updating RDF implementation links to the new website: https://github.com/root-project/analysis-grand-challenge.