### PR TITLE
ci: add ruff linter check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,11 +4,16 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: 3
 
 jobs:
-
-  test:
+  sphinx:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -20,3 +25,11 @@ jobs:
         run: |
           pip install -r docs/requirements.txt
           sphinx-build docs docs/_build
+
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: jpetrucciani/ruff-check@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+# ignore too long lines and ; at the end of a line
+ignore = ["E501", "E703"]


### PR DESCRIPTION
Depends on #148 , but since the only pending item in #148 is about a script in the `workshop` directory and we exclude that directory from the ruff check, #148 could also be merged as it is and it would make the linter check from this PR green.