### PR TITLE
CI: configure pre-commit with ruff and other simple checks, run pre-commit in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,10 +26,11 @@ jobs:
           pip install -r docs/requirements.txt
           sphinx-build docs docs/_build
 
-  linter:
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: jpetrucciani/ruff-check@main
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,20 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/mwouts/jupytext
-    rev: v1.14.1  # CURRENT_TAG/COMMIT_HASH
-    hooks:
-    - id: jupytext
-      args: [--sync]
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.2.0
+  hooks:
+  - id: check-yaml
+  - id: check-added-large-files
+
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.0.272
+  hooks:
+    - id: ruff
+
+- repo: https://github.com/mwouts/jupytext
+  rev: v1.14.6
+  hooks:
+  - id: jupytext
+    args: [--sync]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.ruff]
 # ignore too long lines and ; at the end of a line
 ignore = ["E501", "E703"]
+
+[tool.jupytext]
+formats = "ipynb,py:percent"


### PR DESCRIPTION
Trying this out as @alexander-held mentioned it might be useful.

The only issue is that jupytext processes a lot of notebooks or python scripts that it has no business processing. I did not find an obvious way to restrict jupytext to only run on certain files. We could run it "manually" on the notebooks we care about but I guess it would be more elegant to do it via the pre-commit hook.

Suggestions are welcome :D 