### PR TITLE
fix: make ServiceX dataset grouping compatible with root protocol

### DIFF
--- a/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.ipynb
+++ b/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.ipynb
@@ -928,10 +928,10 @@
    },
    "outputs": [],
    "source": [
-    "config = cabinetry.configuration.load(\"cabinetry_config.yml\")\n",
-    "cabinetry.templates.collect(config)\n",
-    "cabinetry.templates.postprocess(config)  # optional post-processing (e.g. smoothing)\n",
-    "ws = cabinetry.workspace.build(config)\n",
+    "cabinetry_config = cabinetry.configuration.load(\"cabinetry_config.yml\")\n",
+    "cabinetry.templates.collect(cabinetry_config)\n",
+    "cabinetry.templates.postprocess(cabinetry_config)  # optional post-processing (e.g. smoothing)\n",
+    "ws = cabinetry.workspace.build(cabinetry_config)\n",
     "cabinetry.workspace.save(ws, \"workspace.json\")"
    ]
   },
@@ -1099,9 +1099,9 @@
    "source": [
     "model_prediction = cabinetry.model_utils.prediction(model)\n",
     "model_prediction_postfit = cabinetry.model_utils.prediction(model, fit_results=fit_results)\n",
-    "figs = cabinetry.visualize.data_mc(model_prediction, data, close_figure=True, config=config)\n",
+    "figs = cabinetry.visualize.data_mc(model_prediction, data, close_figure=True, config=cabinetry_config)\n",
     "# below method reimplements this visualization in a grid view\n",
-    "utils.plotting.plot_data_mc(model_prediction, model_prediction_postfit, data, config)"
+    "utils.plotting.plot_data_mc(model_prediction, model_prediction_postfit, data, cabinetry_config)"
    ]
   },
   {

--- a/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.py
+++ b/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.py
@@ -644,10 +644,10 @@ if USE_INFERENCE:
 # We will use `cabinetry` to combine all histograms into a `pyhf` workspace and fit the resulting statistical model to the pseudodata we built.
 
 # %% tags=[]
-config = cabinetry.configuration.load("cabinetry_config.yml")
-cabinetry.templates.collect(config)
-cabinetry.templates.postprocess(config)  # optional post-processing (e.g. smoothing)
-ws = cabinetry.workspace.build(config)
+cabinetry_config = cabinetry.configuration.load("cabinetry_config.yml")
+cabinetry.templates.collect(cabinetry_config)
+cabinetry.templates.postprocess(cabinetry_config)  # optional post-processing (e.g. smoothing)
+ws = cabinetry.workspace.build(cabinetry_config)
 cabinetry.workspace.save(ws, "workspace.json")
 
 # %% [markdown]
@@ -681,9 +681,9 @@ print(f"\nfit result for ttbar_norm: {fit_results.bestfit[poi_index]:.3f} +/- {f
 # %%
 model_prediction = cabinetry.model_utils.prediction(model)
 model_prediction_postfit = cabinetry.model_utils.prediction(model, fit_results=fit_results)
-figs = cabinetry.visualize.data_mc(model_prediction, data, close_figure=True, config=config)
+figs = cabinetry.visualize.data_mc(model_prediction, data, close_figure=True, config=cabinetry_config)
 # below method reimplements this visualization in a grid view
-utils.plotting.plot_data_mc(model_prediction, model_prediction_postfit, data, config)
+utils.plotting.plot_data_mc(model_prediction, model_prediction_postfit, data, cabinetry_config)
 
 # %% [markdown]
 # ### ML Validation

--- a/analyses/cms-open-data-ttbar/utils/file_input.py
+++ b/analyses/cms-open-data-ttbar/utils/file_input.py
@@ -136,7 +136,7 @@ class ServiceXDatasetGroup():
             # (replacing / with : to mitigate servicex filename convention )
             parent_key = np.array([np.where(parent_file_urls==self.filelist[i][0].replace("/",":"))[0][0]
                                    for i in range(len(self.filelist))])
-        except:
+        except IndexError:
             # fallback solution that relies splitting via the port (name only changes before that)
             # probably not very stable and general! this may fail - please report back if you observe that happening
             # TODO: find something more stable

--- a/analyses/cms-open-data-ttbar/utils/file_input.py
+++ b/analyses/cms-open-data-ttbar/utils/file_input.py
@@ -128,12 +128,21 @@ class ServiceXDatasetGroup():
     def get_data_rootfiles_uri(self, query, as_signed_url=True, title="Untitled"):
 
         all_files = np.array(self.ds.get_data_rootfiles_uri(query, as_signed_url=as_signed_url, title=title))
-        parent_file_urls = np.array([f.file for f in all_files])
+        try:
+            # default matching for when ServiceX doesn't abbreviate names
+            parent_file_urls = np.array([f.file for f in all_files])
 
-        # order is not retained after transform, so we can match files to their parent files using the filename
-        # (replacing / with : to mitigate servicex filename convention )
-        parent_key = np.array([np.where(parent_file_urls==self.filelist[i][0].replace("/",":"))[0][0]
-                               for i in range(len(self.filelist))])
+            # order is not retained after transform, so we can match files to their parent files using the filename
+            # (replacing / with : to mitigate servicex filename convention )
+            parent_key = np.array([np.where(parent_file_urls==self.filelist[i][0].replace("/",":"))[0][0]
+                                   for i in range(len(self.filelist))])
+        except:
+            # fallback solution that relies splitting via the port (name only changes before that)
+            # probably not very stable and general! this may fail - please report back if you observe that happening
+            # TODO: find something more stable
+            parent_file_urls = np.asarray([f.replace(":", "/").split("1094//")[-1] for f in np.array([f.file for f in all_files])])
+            parent_key = np.array([np.where(parent_file_urls==self.filelist[i][0].split("1094//")[-1])[0][0]
+                                   for i in range(len(self.filelist))])
 
         files_per_process = {}
         for i, process in enumerate(self.fileset):


### PR DESCRIPTION
This allows using `root://` instead of just https. In practice, the problem seems to be that some parent paths have a different format that expected. This was tested at the UChicago AF. A standard path looks like this

```
root:::xcache.af.uchicago.edu:1094::root:::xrootd-local.unl.edu:1094::store:user:AGC:nanoAOD:TT_TuneCUETP8M1_13TeV-powheg-pythia8:cmsopendata2015_ttbar_19980_PU25nsData2015v1_76X_mcRun2_asymptotic_v12_ext3-v1_00000_0000.root
```

while some paths instead look like the following:
```
_0550680f54153965e73292ef2c94b7a94dc4a8f5edu:1094::store:user:AGC:nanoAOD:ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1:cmsopendata2015_single_top_t_chan_19408_PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1_00000_0006.root
```

Using the same approach as in the backport #196: split at the port if the default method does not work. This is likely fragile and needs a better implementation in the long term.

Additional small update: do not override `config` with the cabinetry configuration information to simplify partial re-runs of the notebook.