### PR TITLE
feat: updated validation script to check partial bin sums

### DIFF
--- a/analyses/cms-open-data-ttbar/validate_histograms.py
+++ b/analyses/cms-open-data-ttbar/validate_histograms.py
@@ -73,7 +73,7 @@ def validate(histos: dict, reference: dict, verbose=False) -> dict[str, list[str
                 h_group = np.array(h['contents'])[group]
                 ref_group = np.array(ref_h['contents'])[group]
                 # if difference is great, count as error
-                if not np.allclose(h_group, ref_group, atol=2.0):
+                if not np.allclose(h_group, ref_group, atol=2.0): # 2.0 is chosen as it seems to cover the difference expected of one events migrating between bins in histograms from 1 file per sample. this definitely can be tuned in the future
                     is_error = True
                     if verbose:
                         print(f"In {name}: Not close enough for bin migration")

--- a/analyses/cms-open-data-ttbar/validate_histograms.py
+++ b/analyses/cms-open-data-ttbar/validate_histograms.py
@@ -43,12 +43,11 @@ def validate(histos: dict, reference: dict, verbose=False) -> dict[str, list[str
         if not np.allclose(h['edges'], ref_h['edges']):
             errors[name].append(f"Edges do not match:\n\tgot      {h['edges']}\n\texpected {ref_h['edges']}")
         contents_depend_on_rng = "pt_res_up" in name # skip checking the contents of these histograms as they are not stable
+        is_close = np.isclose(h['contents'], ref_h['contents']) 
+        
+        #### check if bin migration ####
+        if not contents_depend_on_rng and not all(is_close):
 
-        if not contents_depend_on_rng and not np.allclose(h['contents'], ref_h['contents']):
-
-            #### check if bin migration ####
-            # returns boolean array that returns false elementwise if not close
-            is_close = np.isclose(h['contents'], ref_h['contents']) 
             # gets indices where above array is false
             where_not_close = np.where(np.invert(is_close))[0]
             # gets difference of adjacent entries

--- a/analyses/cms-open-data-ttbar/validate_histograms.py
+++ b/analyses/cms-open-data-ttbar/validate_histograms.py
@@ -65,17 +65,14 @@ def validate(histos: dict, reference: dict) -> dict[str, list[str]]:
                 ref_group = np.array(ref_h['contents'])[group]
                 # if difference is great, count as error
                 if not np.allclose(h_group, ref_group, atol=5e-1):
-                    print("Adjacent bins have difference which is too great:")
-                    print("histogram: ", h_group, ", reference: ", ref_group)
-                    print()
                     is_error = True
                 # check partial sum
                 if not np.allclose(sum(h_group), sum(ref_group)):
-                    print("Partial sum is not equal:")
+                    is_error = True
+                else:
+                    print("Bin migration likely:")
                     print("histogram: ", h_group, ", reference: ", ref_group)
                     print()
-                    is_error = True
-
             if is_error:
                 errors[name].append(f"Contents do not match:\n\tgot      {h['contents']}\n\texpected {ref_h['contents']}")
 


### PR DESCRIPTION
This is an attempt to address #168 . If adjacent bins are similar enough, the partial sum of the affected bins is compared. This will ensure that one event migrating across bins will not flag as an error. Maybe we can test this with RDF implementation (@andriiknu)

@alexander-held @eguiraud 