### PR TITLE
feat: do not require pseudodata hists in validate_histograms.py

### DIFF
--- a/analyses/cms-open-data-ttbar/validate_histograms.py
+++ b/analyses/cms-open-data-ttbar/validate_histograms.py
@@ -36,7 +36,9 @@ def validate(histos: dict, reference: dict, verbose=False) -> dict[str, list[str
     errors = defaultdict(list)
     for name, ref_h in reference.items():
         if name not in histos:
-            errors[name].append("Histogram not found.")
+            # not an error if pseudodata histograms are missing
+            if name != "4j1b_pseudodata" and name != "4j2b_pseudodata":
+                errors[name].append("Histogram not found.")
             continue
 
         h = histos[name]


### PR DESCRIPTION
These histograms are needed for the statistical inference stage, but they are built from other histograms and it is up to the implementation whether to write out dedicated pseudodata histograms or build them on the fly.

If approved I'll backport to the v1 branch.