### PR TITLE
feat: fixes towards v1.2

### DIFF
--- a/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.ipynb
+++ b/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f4bdc262",
    "metadata": {},
@@ -24,6 +25,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "49c44094",
    "metadata": {},
@@ -35,6 +37,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "991a4343",
    "metadata": {},
@@ -77,6 +80,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "808b4789",
    "metadata": {},
@@ -130,6 +134,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a22d0859",
    "metadata": {},
@@ -249,7 +254,7 @@
     "            event_filters = event_filters & (ak.count(selected_jets.pt * pt_var_modifier, axis=1) >= 4)\n",
     "            # at least one b-tagged jet (\"tag\" means score above threshold)\n",
     "            B_TAG_THRESHOLD = 0.5\n",
-    "            event_filters = event_filters & (ak.sum(selected_jets.btagCSVV2 >= B_TAG_THRESHOLD, axis=1) >= 1)\n",
+    "            event_filters = event_filters & (ak.sum(selected_jets.btagCSVV2 > B_TAG_THRESHOLD, axis=1) >= 1)\n",
     "\n",
     "            # apply event filters\n",
     "            selected_events = events[event_filters]\n",
@@ -260,7 +265,7 @@
     "            for region in [\"4j1b\", \"4j2b\"]:\n",
     "                # further filtering: 4j1b CR with single b-tag, 4j2b SR with two or more tags\n",
     "                if region == \"4j1b\":\n",
-    "                    region_filter = ak.sum(selected_jets.btagCSVV2 >= B_TAG_THRESHOLD, axis=1) == 1\n",
+    "                    region_filter = ak.sum(selected_jets.btagCSVV2 > B_TAG_THRESHOLD, axis=1) == 1\n",
     "                    selected_jets_region = selected_jets[region_filter]\n",
     "                    # use HT (scalar sum of jet pT) as observable\n",
     "                    pt_var_modifier = (\n",
@@ -349,6 +354,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3243414e",
    "metadata": {},
@@ -389,6 +395,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b0b27a46",
    "metadata": {},
@@ -410,12 +417,12 @@
     "def get_query(source: ObjectStream) -> ObjectStream:\n",
     "    \"\"\"Query for event / column selection: >=4j >=1b, ==1 lep with pT>25 GeV, return relevant columns\n",
     "    \"\"\"\n",
-    "    return source.Where(lambda e: e.Electron_pt.Where(lambda pt: pt > 25).Count() \n",
+    "    return source.Where(lambda e: e.Electron_pt.Where(lambda pt: pt > 25).Count()\n",
     "                        + e.Muon_pt.Where(lambda pt: pt > 25).Count() == 1)\\\n",
     "                 .Where(lambda f: f.Jet_pt.Where(lambda pt: pt > 25).Count() >= 4)\\\n",
-    "                 .Where(lambda g: {\"pt\": g.Jet_pt, \n",
-    "                                   \"btagCSVV2\": g.Jet_btagCSVV2}.Zip().Where(lambda jet: \n",
-    "                                                                             jet.btagCSVV2 >= 0.5 \n",
+    "                 .Where(lambda g: {\"pt\": g.Jet_pt,\n",
+    "                                   \"btagCSVV2\": g.Jet_btagCSVV2}.Zip().Where(lambda jet:\n",
+    "                                                                             jet.btagCSVV2 > 0.5\n",
     "                                                                             and jet.pt > 25).Count() >= 1)\\\n",
     "                 .Select(lambda h: {\"Electron_pt\": h.Electron_pt,\n",
     "                                    \"Muon_pt\": h.Muon_pt,\n",
@@ -428,6 +435,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2114307f",
    "metadata": {},
@@ -470,6 +478,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "62bbc8c8",
    "metadata": {},
@@ -590,6 +599,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b66c8142",
    "metadata": {},
@@ -655,6 +665,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5feb786b",
    "metadata": {},
@@ -729,6 +740,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9f861625",
    "metadata": {},
@@ -752,6 +764,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6ea49c8e-2d20-47d5-8fd6-2f51e4ef1e0e",
    "metadata": {},
@@ -786,6 +799,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6feae4d5",
    "metadata": {},
@@ -833,6 +847,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "aab2493c",
    "metadata": {},
@@ -877,6 +892,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fe677e60",
    "metadata": {},
@@ -907,6 +923,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "35e5a9aa",
    "metadata": {},
@@ -966,6 +983,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9908c2a2",
    "metadata": {},
@@ -1024,6 +1042,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "269f8c3a",
    "metadata": {},
@@ -1060,7 +1079,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.py
+++ b/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.1
+#       jupytext_version: 1.14.7
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -40,7 +40,7 @@
 # %% [markdown]
 # ### Imports: setting up our environment
 
-# %% tags=[]
+# %%
 import asyncio
 import logging
 import os
@@ -89,7 +89,7 @@ logging.getLogger("cabinetry").setLevel(logging.INFO)
 #
 # The input files are all in the 1–3 GB range.
 
-# %% tags=[]
+# %%
 ### GLOBAL CONFIGURATION
 # input files per process, set to e.g. 10 (smaller number = faster)
 N_FILES_MAX_PER_SAMPLE = 5
@@ -114,7 +114,7 @@ with open("config.yaml") as config_file:
 # - calculating systematic uncertainties at the event and object level,
 # - filling all the information into histograms that get aggregated and ultimately returned to us by `coffea`.
 
-# %% tags=[]
+# %%
 # functions creating systematic variations
 def flat_variation(ones):
     # 2.5% weight variations
@@ -212,7 +212,7 @@ class TtbarAnalysis(processor.ProcessorABC):
             event_filters = event_filters & (ak.count(selected_jets.pt * pt_var_modifier, axis=1) >= 4)
             # at least one b-tagged jet ("tag" means score above threshold)
             B_TAG_THRESHOLD = 0.5
-            event_filters = event_filters & (ak.sum(selected_jets.btagCSVV2 >= B_TAG_THRESHOLD, axis=1) >= 1)
+            event_filters = event_filters & (ak.sum(selected_jets.btagCSVV2 > B_TAG_THRESHOLD, axis=1) >= 1)
 
             # apply event filters
             selected_events = events[event_filters]
@@ -223,7 +223,7 @@ class TtbarAnalysis(processor.ProcessorABC):
             for region in ["4j1b", "4j2b"]:
                 # further filtering: 4j1b CR with single b-tag, 4j2b SR with two or more tags
                 if region == "4j1b":
-                    region_filter = ak.sum(selected_jets.btagCSVV2 >= B_TAG_THRESHOLD, axis=1) == 1
+                    region_filter = ak.sum(selected_jets.btagCSVV2 > B_TAG_THRESHOLD, axis=1) == 1
                     selected_jets_region = selected_jets[region_filter]
                     # use HT (scalar sum of jet pT) as observable
                     pt_var_modifier = (
@@ -316,7 +316,7 @@ class TtbarAnalysis(processor.ProcessorABC):
 #
 # Here, we gather all the required information about the files we want to process: paths to the files and asociated metadata.
 
-# %% tags=[]
+# %%
 fileset = utils.construct_fileset(N_FILES_MAX_PER_SAMPLE, use_xcache=False, af_name=config["benchmarking"]["AF_NAME"])  # local files on /data for ssl-dev
 
 print(f"processes in fileset: {list(fileset.keys())}")
@@ -329,16 +329,16 @@ print(f"  'metadata': {fileset['ttbar__nominal']['metadata']}\n}}")
 #
 # Define the func_adl query to be used for the purpose of extracting columns and filtering.
 
-# %% tags=[]
+# %%
 def get_query(source: ObjectStream) -> ObjectStream:
     """Query for event / column selection: >=4j >=1b, ==1 lep with pT>25 GeV, return relevant columns
     """
-    return source.Where(lambda e: e.Electron_pt.Where(lambda pt: pt > 25).Count() 
+    return source.Where(lambda e: e.Electron_pt.Where(lambda pt: pt > 25).Count()
                         + e.Muon_pt.Where(lambda pt: pt > 25).Count() == 1)\
                  .Where(lambda f: f.Jet_pt.Where(lambda pt: pt > 25).Count() >= 4)\
-                 .Where(lambda g: {"pt": g.Jet_pt, 
-                                   "btagCSVV2": g.Jet_btagCSVV2}.Zip().Where(lambda jet: 
-                                                                             jet.btagCSVV2 >= 0.5 
+                 .Where(lambda g: {"pt": g.Jet_pt,
+                                   "btagCSVV2": g.Jet_btagCSVV2}.Zip().Where(lambda jet:
+                                                                             jet.btagCSVV2 > 0.5
                                                                              and jet.pt > 25).Count() >= 1)\
                  .Select(lambda h: {"Electron_pt": h.Electron_pt,
                                     "Muon_pt": h.Muon_pt,
@@ -355,7 +355,7 @@ def get_query(source: ObjectStream) -> ObjectStream:
 #
 # Using the queries created with `func_adl`, we are using `ServiceX` to read the CMS Open Data files to build cached files with only the specific event information as dictated by the query.
 
-# %% tags=[]
+# %%
 if USE_SERVICEX:
     # dummy dataset on which to generate the query
     dummy_ds = ServiceXSourceUpROOT("cernopendata://dummy", "Events", backend_name="uproot")
@@ -385,7 +385,7 @@ if USE_SERVICEX:
 #
 # When `USE_SERVICEX` is false, the input files need to be processed during this step as well.
 
-# %% tags=[]
+# %%
 NanoAODSchema.warn_missing_crossrefs = False # silences warnings about branches we will not use here
 if USE_DASK:
     executor = processor.DaskExecutor(client=utils.get_client(af=config["global"]["AF"]))
@@ -410,7 +410,7 @@ all_histograms = all_histograms["hist"]
 
 print(f"\nexecution took {exec_time:.2f} seconds")
 
-# %% tags=[]
+# %%
 # track metrics
 dataset_source = "/data" if fileset["ttbar__nominal"]["files"][0].startswith("/data") else "https://xrootd-local.unl.edu:1094" # TODO: xcache support
 metrics.update({
@@ -448,7 +448,7 @@ print(f"amount of data read: {metrics['bytesread']/1000**2:.2f} MB")  # likely b
 # Let's have a look at the data we obtained.
 # We built histograms in two phase space regions, for multiple physics processes and systematic variations.
 
-# %% tags=[]
+# %%
 utils.set_style()
 
 all_histograms[120j::hist.rebin(2), "4j1b", :, "nominal"].stack("process")[::-1].plot(stack=True, histtype="fill", linewidth=1, edgecolor="grey")
@@ -456,7 +456,7 @@ plt.legend(frameon=False)
 plt.title(">= 4 jets, 1 b-tag")
 plt.xlabel("HT [GeV]");
 
-# %% tags=[]
+# %%
 all_histograms[:, "4j2b", :, "nominal"].stack("process")[::-1].plot(stack=True, histtype="fill", linewidth=1,edgecolor="grey")
 plt.legend(frameon=False)
 plt.title(">= 4 jets, >= 2 b-tags")
@@ -471,7 +471,7 @@ plt.xlabel("$m_{bjj}$ [Gev]");
 #
 # We are making of [UHI](https://uhi.readthedocs.io/) here to re-bin.
 
-# %% tags=[]
+# %%
 # b-tagging variations
 all_histograms[120j::hist.rebin(2), "4j1b", "ttbar", "nominal"].plot(label="nominal", linewidth=2)
 all_histograms[120j::hist.rebin(2), "4j1b", "ttbar", "btag_var_0_up"].plot(label="NP 1", linewidth=2)
@@ -482,7 +482,7 @@ plt.legend(frameon=False)
 plt.xlabel("HT [GeV]")
 plt.title("b-tagging variations");
 
-# %% tags=[]
+# %%
 # jet energy scale variations
 all_histograms[:, "4j2b", "ttbar", "nominal"].plot(label="nominal", linewidth=2)
 all_histograms[:, "4j2b", "ttbar", "pt_scale_up"].plot(label="scale up", linewidth=2)
@@ -497,7 +497,7 @@ plt.title("Jet energy variations");
 # We'll save everything to disk for subsequent usage.
 # This also builds pseudo-data by combining events from the various simulation setups we have processed.
 
-# %% tags=[]
+# %%
 utils.save_histograms(all_histograms, fileset, "histograms.root")
 
 # %% [markdown]
@@ -510,7 +510,7 @@ utils.save_histograms(all_histograms, fileset, "histograms.root")
 # A statistical model has been defined in `config.yml`, ready to be used with our output.
 # We will use `cabinetry` to combine all histograms into a `pyhf` workspace and fit the resulting statistical model to the pseudodata we built.
 
-# %% tags=[]
+# %%
 config = cabinetry.configuration.load("cabinetry_config.yml")
 
 # rebinning: lower edge 110 GeV, merge bins 2->1
@@ -523,13 +523,13 @@ cabinetry.workspace.save(ws, "workspace.json")
 # %% [markdown]
 # We can inspect the workspace with `pyhf`, or use `pyhf` to perform inference.
 
-# %% tags=[]
+# %%
 # !pyhf inspect workspace.json | head -n 20
 
 # %% [markdown]
 # Let's try out what we built: the next cell will perform a maximum likelihood fit of our statistical model to the pseudodata we built.
 
-# %% tags=[]
+# %%
 model, data = cabinetry.model_utils.model_and_data(ws)
 fit_results = cabinetry.fit.fit(model, data)
 
@@ -540,7 +540,7 @@ cabinetry.visualize.pulls(
 # %% [markdown]
 # For this pseudodata, what is the resulting ttbar cross-section divided by the Standard Model prediction?
 
-# %% tags=[]
+# %%
 poi_index = model.config.poi_index
 print(f"\nfit result for ttbar_norm: {fit_results.bestfit[poi_index]:.3f} +/- {fit_results.uncertainty[poi_index]:.3f}")
 
@@ -548,23 +548,23 @@ print(f"\nfit result for ttbar_norm: {fit_results.bestfit[poi_index]:.3f} +/- {f
 # Let's also visualize the model before and after the fit, in both the regions we are using.
 # The binning here corresponds to the binning used for the fit.
 
-# %% tags=[]
+# %%
 model_prediction = cabinetry.model_utils.prediction(model)
 figs = cabinetry.visualize.data_mc(model_prediction, data, close_figure=True, config=config)
 figs[0]["figure"]
 
-# %% tags=[]
+# %%
 figs[1]["figure"]
 
 # %% [markdown]
 # We can see very good post-fit agreement.
 
-# %% tags=[]
+# %%
 model_prediction_postfit = cabinetry.model_utils.prediction(model, fit_results=fit_results)
 figs = cabinetry.visualize.data_mc(model_prediction_postfit, data, close_figure=True, config=config)
 figs[0]["figure"]
 
-# %% tags=[]
+# %%
 figs[1]["figure"]
 
 # %% [markdown]

--- a/analyses/cms-open-data-ttbar/utils/__init__.py
+++ b/analyses/cms-open-data-ttbar/utils/__init__.py
@@ -93,8 +93,6 @@ def construct_fileset(n_files_max_per_sample, use_xcache=False, af_name=""):
 def save_histograms(all_histograms, fileset, filename):
     nominal_samples = [sample for sample in fileset.keys() if "nominal" in sample]
 
-    all_histograms += 1e-6  # add minimal event count to all bins to avoid crashes when processing a small number of samples
-
     pseudo_data = (all_histograms[:, :, "ttbar", "ME_var"] + all_histograms[:, :, "ttbar", "PS_var"]) / 2  + all_histograms[:, :, "wjets", "nominal"]
 
     with uproot.recreate(filename) as f:


### PR DESCRIPTION
This fixes two more issues in the v1.1.0 tag and updates references:

- fix the b-tagging threshold comparison to use `>` instead of `>=` (see #174)
- remove the histogram event offsetting by 1e-6 (see https://github.com/iris-hep/analysis-grand-challenge/issues/166#issuecomment-1642607883)
- update reference histograms accordingly

cc @eguiraud 