### PR TITLE
docs: add v1.2 description and fix cut descriptions

### DIFF
--- a/docs/taskbackground.rst
+++ b/docs/taskbackground.rst
@@ -269,7 +269,7 @@ This is visualized in the diagram below:
   :width: 80%
   :alt: Diagram of a :math:`t\bar{t}` event with the three machine learning labels for jets.
   
-In each event, we consider each permutation of jets assigned to these labels, restricting to the leading :math:`N` jets. 
+In each event, we consider each permutation of jets assigned to these labels, restricting to the leading (in :math:`p_T`) :math:`N` jets. 
 The number of such permutations (assuming the event has at least :math:`N` jets and that :math:`N\geq 4`) is :math:`N!/(2\cdot (N-4)!)`. 
 For example, if there are 4 jets in an event, we consider :math:`4!/2=12` permutations. 
 The :math:`4!` comes from labelling 4 jets, while dividing by 2 accounts for the fact that two of the jets are labelled indistinguishably. 

--- a/docs/taskbackground.rst
+++ b/docs/taskbackground.rst
@@ -70,7 +70,7 @@ The tree of the above event looks something like
 To ensure that we retain the highest possible purity of :math:`t\bar{t}` events in the signal region, we make the following cuts:
 
 * Events must contain exactly one lepton, which must have :math:`p_T>30` GeV, :math:`|\eta|<2.1`, and ``sip3d<4`` (significance of 3d impact parameter)
-* Jets must have :math:`p_T>30` GeV and :math:`|\eta|>2.4` as well as satisfy ``isTightLeptonVeto``
+* Jets must have :math:`p_T>30` GeV and :math:`|\eta|<2.4` and satisfy a tight lepton veto (``isTightLeptonVeto``, or ``jetId==6``)
 * Events must have at least four jets
 * Events must have exactly one :math:`b`-tagged jet
 

--- a/docs/versionsdescription.rst
+++ b/docs/versionsdescription.rst
@@ -212,7 +212,7 @@ This is modified to better reflect common practices in CMS in subsequent version
 * For electrons, we also require ``cutBased==4`` (tight)
 * For muons, we also require ``tightId`` and ``pfRelIso04_all<0.15`` (PF relative isolation dR=0.4, total (deltaBeta corrections))
 * Events must contain exactly one lepton
-* Jets must have :math:`p_T>30` GeV and :math:`|\eta|>2.4` as well as satisfy ``isTightLeptonVeto``
+* Jets must have :math:`p_T>30` GeV and :math:`|\eta|<2.4` and satisfy a tight lepton veto (``isTightLeptonVeto``, or ``jetId==6``)
 * Events must have at least four jets
 * Jets are considered :math:`b`-tagged if they have a :math:`b`-tag score over `B_TAG_THRESHOLD=0.5`.
 * Events must have at least one :math:`b`-tagged jet

--- a/docs/versionsdescription.rst
+++ b/docs/versionsdescription.rst
@@ -68,6 +68,11 @@ Our reference implementation for each major task (0, 1, 2) will always be the la
      - Pure ``coffea``; create cached files using ``ServiceX`` queries followed by standalone ``coffea`` processing
      - Systematic variations within ``coffea`` processor are manually calculated using ``awkward`` array logic (jet :math:`p_T` variations corrected)
      - Functions used in ``coffea`` processor are defined in the notebook
+   * - 1.2.0
+     - 1
+     - Pure ``coffea``; create cached files using ``ServiceX`` queries followed by standalone ``coffea`` processing
+     - Systematic variations within ``coffea`` processor are manually calculated using ``awkward`` array logic (b-tagging cuts corrected, no 1e-6 offsetting of histogram yields)
+     - Functions used in ``coffea`` processor are defined in the notebook
    * - 2.0.0 (WIP)
      - 2
      - Pure ``coffea``; create cached files using ``ServiceX`` queries followed by standalone ``coffea`` processing; optional machine learning component (with additional option to use ``NVIDIA Triton`` inference server)


### PR DESCRIPTION
Adding a description of the v1.2 tag, fixing the jet eta cut and explaining how to obtain the tight lepton veto via the variable provided in the input files. Also clarify how to pick jets for the ML part if not considering all permutations.