### PR TITLE
fix: set bin edge cuts to 110 GeV instead of 120 GeV

### DIFF
--- a/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.ipynb
+++ b/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f4bdc262",
    "metadata": {},
@@ -24,6 +25,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "49c44094",
    "metadata": {},
@@ -35,6 +37,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "991a4343",
    "metadata": {},
@@ -77,6 +80,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "808b4789",
    "metadata": {},
@@ -130,6 +134,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a22d0859",
    "metadata": {},
@@ -349,6 +354,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "3243414e",
    "metadata": {},
@@ -389,6 +395,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b0b27a46",
    "metadata": {},
@@ -428,6 +435,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2114307f",
    "metadata": {},
@@ -470,6 +478,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "62bbc8c8",
    "metadata": {},
@@ -590,6 +599,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b66c8142",
    "metadata": {},
@@ -622,7 +632,7 @@
    "source": [
     "utils.set_style()\n",
     "\n",
-    "all_histograms[120j::hist.rebin(2), \"4j1b\", :, \"nominal\"].stack(\"process\")[::-1].plot(stack=True, histtype=\"fill\", linewidth=1, edgecolor=\"grey\")\n",
+    "all_histograms[110j::hist.rebin(2), \"4j1b\", :, \"nominal\"].stack(\"process\")[::-1].plot(stack=True, histtype=\"fill\", linewidth=1, edgecolor=\"grey\")\n",
     "plt.legend(frameon=False)\n",
     "plt.title(\">= 4 jets, 1 b-tag\")\n",
     "plt.xlabel(\"HT [GeV]\");"
@@ -655,6 +665,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "5feb786b",
    "metadata": {},
@@ -689,11 +700,11 @@
    ],
    "source": [
     "# b-tagging variations\n",
-    "all_histograms[120j::hist.rebin(2), \"4j1b\", \"ttbar\", \"nominal\"].plot(label=\"nominal\", linewidth=2)\n",
-    "all_histograms[120j::hist.rebin(2), \"4j1b\", \"ttbar\", \"btag_var_0_up\"].plot(label=\"NP 1\", linewidth=2)\n",
-    "all_histograms[120j::hist.rebin(2), \"4j1b\", \"ttbar\", \"btag_var_1_up\"].plot(label=\"NP 2\", linewidth=2)\n",
-    "all_histograms[120j::hist.rebin(2), \"4j1b\", \"ttbar\", \"btag_var_2_up\"].plot(label=\"NP 3\", linewidth=2)\n",
-    "all_histograms[120j::hist.rebin(2), \"4j1b\", \"ttbar\", \"btag_var_3_up\"].plot(label=\"NP 4\", linewidth=2)\n",
+    "all_histograms[110j::hist.rebin(2), \"4j1b\", \"ttbar\", \"nominal\"].plot(label=\"nominal\", linewidth=2)\n",
+    "all_histograms[110j::hist.rebin(2), \"4j1b\", \"ttbar\", \"btag_var_0_up\"].plot(label=\"NP 1\", linewidth=2)\n",
+    "all_histograms[110j::hist.rebin(2), \"4j1b\", \"ttbar\", \"btag_var_1_up\"].plot(label=\"NP 2\", linewidth=2)\n",
+    "all_histograms[110j::hist.rebin(2), \"4j1b\", \"ttbar\", \"btag_var_2_up\"].plot(label=\"NP 3\", linewidth=2)\n",
+    "all_histograms[110j::hist.rebin(2), \"4j1b\", \"ttbar\", \"btag_var_3_up\"].plot(label=\"NP 4\", linewidth=2)\n",
     "plt.legend(frameon=False)\n",
     "plt.xlabel(\"HT [GeV]\")\n",
     "plt.title(\"b-tagging variations\");"
@@ -729,6 +740,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9f861625",
    "metadata": {},
@@ -752,6 +764,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6ea49c8e-2d20-47d5-8fd6-2f51e4ef1e0e",
    "metadata": {},
@@ -786,6 +799,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "6feae4d5",
    "metadata": {},
@@ -833,6 +847,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "aab2493c",
    "metadata": {},
@@ -877,6 +892,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "fe677e60",
    "metadata": {},
@@ -907,6 +923,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "35e5a9aa",
    "metadata": {},
@@ -966,6 +983,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9908c2a2",
    "metadata": {},
@@ -1024,6 +1042,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "269f8c3a",
    "metadata": {},
@@ -1060,7 +1079,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.py
+++ b/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.py
@@ -451,7 +451,7 @@ print(f"amount of data read: {metrics['bytesread']/1000**2:.2f} MB")  # likely b
 # %% tags=[]
 utils.set_style()
 
-all_histograms[120j::hist.rebin(2), "4j1b", :, "nominal"].stack("process")[::-1].plot(stack=True, histtype="fill", linewidth=1, edgecolor="grey")
+all_histograms[110j::hist.rebin(2), "4j1b", :, "nominal"].stack("process")[::-1].plot(stack=True, histtype="fill", linewidth=1, edgecolor="grey")
 plt.legend(frameon=False)
 plt.title(">= 4 jets, 1 b-tag")
 plt.xlabel("HT [GeV]");
@@ -473,11 +473,11 @@ plt.xlabel("$m_{bjj}$ [Gev]");
 
 # %% tags=[]
 # b-tagging variations
-all_histograms[120j::hist.rebin(2), "4j1b", "ttbar", "nominal"].plot(label="nominal", linewidth=2)
-all_histograms[120j::hist.rebin(2), "4j1b", "ttbar", "btag_var_0_up"].plot(label="NP 1", linewidth=2)
-all_histograms[120j::hist.rebin(2), "4j1b", "ttbar", "btag_var_1_up"].plot(label="NP 2", linewidth=2)
-all_histograms[120j::hist.rebin(2), "4j1b", "ttbar", "btag_var_2_up"].plot(label="NP 3", linewidth=2)
-all_histograms[120j::hist.rebin(2), "4j1b", "ttbar", "btag_var_3_up"].plot(label="NP 4", linewidth=2)
+all_histograms[110j::hist.rebin(2), "4j1b", "ttbar", "nominal"].plot(label="nominal", linewidth=2)
+all_histograms[110j::hist.rebin(2), "4j1b", "ttbar", "btag_var_0_up"].plot(label="NP 1", linewidth=2)
+all_histograms[110j::hist.rebin(2), "4j1b", "ttbar", "btag_var_1_up"].plot(label="NP 2", linewidth=2)
+all_histograms[110j::hist.rebin(2), "4j1b", "ttbar", "btag_var_2_up"].plot(label="NP 3", linewidth=2)
+all_histograms[110j::hist.rebin(2), "4j1b", "ttbar", "btag_var_3_up"].plot(label="NP 4", linewidth=2)
 plt.legend(frameon=False)
 plt.xlabel("HT [GeV]")
 plt.title("b-tagging variations");


### PR DESCRIPTION
Fixes cut values during histogram re-binning to correspond to actual bin edges. This does not change functionality but is a more natural and readable way to specify the operation.

Thanks to @eguiraud for spotting!