### PR TITLE
feat: support input files on public EOS

### DIFF
--- a/analyses/cms-open-data-ttbar/config.yaml
+++ b/analyses/cms-open-data-ttbar/config.yaml
@@ -12,7 +12,7 @@ benchmarking:
   CHUNKSIZE: 500000
 
   # read files from public EOS (thanks to the CMS DPOA team!)
-  INPUT_FROM_EOS: true
+  INPUT_FROM_EOS: false
 
   # metadata to propagate through to metrics
   # "ssl-dev" allows for the switch to local data on /data

--- a/analyses/cms-open-data-ttbar/config.yaml
+++ b/analyses/cms-open-data-ttbar/config.yaml
@@ -2,35 +2,38 @@ global:
 
   # ServiceX: ignore cache with repeated queries
   SERVICEX_IGNORE_CACHE: false
-  
+
   # analysis facility: set to "coffea_casa" for coffea-casa environments, "EAF" for FNAL, "local" for local setups
   AF: coffea_casa
-  
+
 benchmarking:
 
   # chunk size to use
   CHUNKSIZE: 500000
-  
+
+  # read files from public EOS (thanks to the CMS DPOA team!)
+  INPUT_FROM_EOS: true
+
   # metadata to propagate through to metrics
   # "ssl-dev" allows for the switch to local data on /data
   AF_NAME: coffea_casa
-  
+
   # currently has no effect
   SYSTEMATICS: all
-  
+
   # does not do anything, only used for metric gathering (set to 2 for distributed coffea-casa)
   CORES_PER_WORKER: 2
-  
+
   # scaling for local setups with FuturesExecutor
   NUM_CORES: 4
-  
+
   # only I/O, all other processing disabled
   DISABLE_PROCESSING: false
-  
+
   # read additional branches (only with DISABLE_PROCESSING = True)
   # acceptable values are 4.1, 15, 25, 50 (corresponding to % of file read), 4.1% corresponds to the standard branches used in the notebook
   IO_FILE_PERCENT: '4.1'
-  
+
   # nanoAOD branches that correspond to different values of IO_FILE_PERCENT
   IO_BRANCHES:
     '4.1':

--- a/analyses/cms-open-data-ttbar/config.yaml
+++ b/analyses/cms-open-data-ttbar/config.yaml
@@ -12,6 +12,8 @@ benchmarking:
   CHUNKSIZE: 500000
 
   # read files from public EOS (thanks to the CMS DPOA team!)
+  # note that they are likely only available temporarily
+  # and not part of an official CMS Open Data release
   INPUT_FROM_EOS: false
 
   # metadata to propagate through to metrics

--- a/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.ipynb
+++ b/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.ipynb
@@ -387,7 +387,12 @@
     }
    ],
    "source": [
-    "fileset = utils.construct_fileset(N_FILES_MAX_PER_SAMPLE, use_xcache=False, af_name=config[\"benchmarking\"][\"AF_NAME\"])  # local files on /data for ssl-dev\n",
+    "fileset = utils.construct_fileset(\n",
+    "                                    N_FILES_MAX_PER_SAMPLE,\n",
+    "                                    use_xcache=False,\n",
+    "                                    af_name=config[\"benchmarking\"][\"AF_NAME\"],\n",
+    "                                    input_from_eos=config[\"benchmarking\"][\"INPUT_FROM_EOS\"]\n",
+    "                                 )  # local files on /data for ssl-dev as af_name\n",
     "\n",
     "print(f\"processes in fileset: {list(fileset.keys())}\")\n",
     "print(f\"\\nexample of information in fileset:\\n{{\\n  'files': [{fileset['ttbar__nominal']['files'][0]}, ...],\")\n",

--- a/analyses/cms-open-data-ttbar/utils/__init__.py
+++ b/analyses/cms-open-data-ttbar/utils/__init__.py
@@ -52,7 +52,6 @@ def set_style():
 def construct_fileset(n_files_max_per_sample, use_xcache=False, af_name="", input_from_eos=False):
     # using https://atlas-groupdata.web.cern.ch/atlas-groupdata/dev/AnalysisTop/TopDataPreparation/XSection-MC15-13TeV.data
     # for reference
-    file_paths = [f.replace("https://xrootd-local.unl.edu:1094//store/user/AGC/nanoAOD", "root://eospublic.cern.ch//eos/opendata/cms/upload/agc/1.0.0/") for f in file_paths]
     # x-secs are in pb
     xsec_info = {
         "ttbar": 396.87 + 332.97, # nonallhad + allhad, keep same x-sec for all

--- a/analyses/cms-open-data-ttbar/utils/__init__.py
+++ b/analyses/cms-open-data-ttbar/utils/__init__.py
@@ -84,7 +84,6 @@ def construct_fileset(n_files_max_per_sample, use_xcache=False, af_name="", inpu
                 # point to local files on /data
                 file_paths = [f.replace("https://xrootd-local.unl.edu:1094//store/user/", "/data/alheld/") for f in file_paths]
             elif input_from_eos:
-                print("using input files from eospublic.cern.ch")
                 file_paths = [f.replace("https://xrootd-local.unl.edu:1094//store/user/AGC/nanoAOD", "root://eospublic.cern.ch//eos/opendata/cms/upload/agc/1.0.0/") for f in file_paths]
             nevts_total = sum([f["nevts"] for f in file_list])
             metadata = {"process": process, "variation": variation, "nevts": nevts_total, "xsec": xsec_info[process]}

--- a/analyses/cms-open-data-ttbar/utils/__init__.py
+++ b/analyses/cms-open-data-ttbar/utils/__init__.py
@@ -49,9 +49,10 @@ def set_style():
     plt.rcParams['text.color'] = "222222"
 
 
-def construct_fileset(n_files_max_per_sample, use_xcache=False, af_name=""):
+def construct_fileset(n_files_max_per_sample, use_xcache=False, af_name="", input_from_eos=False):
     # using https://atlas-groupdata.web.cern.ch/atlas-groupdata/dev/AnalysisTop/TopDataPreparation/XSection-MC15-13TeV.data
     # for reference
+    file_paths = [f.replace("https://xrootd-local.unl.edu:1094//store/user/AGC/nanoAOD", "root://eospublic.cern.ch//eos/opendata/cms/upload/agc/1.0.0/") for f in file_paths]
     # x-secs are in pb
     xsec_info = {
         "ttbar": 396.87 + 332.97, # nonallhad + allhad, keep same x-sec for all
@@ -80,9 +81,12 @@ def construct_fileset(n_files_max_per_sample, use_xcache=False, af_name=""):
             file_paths = [f["path"] for f in file_list]
             if use_xcache:
                 file_paths = [f.replace("https://xrootd-local.unl.edu:1094", "root://red-xcache1.unl.edu") for f in file_paths]
-            if af_name == "ssl-dev":
+            elif af_name == "ssl-dev":
                 # point to local files on /data
                 file_paths = [f.replace("https://xrootd-local.unl.edu:1094//store/user/", "/data/alheld/") for f in file_paths]
+            elif input_from_eos:
+                print("using input files from eospublic.cern.ch")
+                file_paths = [f.replace("https://xrootd-local.unl.edu:1094//store/user/AGC/nanoAOD", "root://eospublic.cern.ch//eos/opendata/cms/upload/agc/1.0.0/") for f in file_paths]
             nevts_total = sum([f["nevts"] for f in file_list])
             metadata = {"process": process, "variation": variation, "nevts": nevts_total, "xsec": xsec_info[process]}
             fileset.update({f"{process}__{variation}": {"files": file_paths, "metadata": metadata}})


### PR DESCRIPTION
This adds a config option `INPUT_FROM_EOS` to the `config.yaml`. It switches the input from https at UNL to xrootd at CERN's EOS.

related: #128