### PR TITLE
feat: move xcache prefix setting to config

### DIFF
--- a/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.ipynb
+++ b/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.ipynb
@@ -445,7 +445,7 @@
     "    use_xcache=False,\n",
     "    af_name=utils.config[\"benchmarking\"][\"AF_NAME\"],  # local files on /data for af_name=\"ssl-dev\"\n",
     "    input_from_eos=utils.config[\"benchmarking\"][\"INPUT_FROM_EOS\"],\n",
-    "    xcache_atlas_prefix=None,  # e.g. \"root://xcache.af.uchicago.edu//\" for UChicago\n",
+    "    xcache_atlas_prefix=utils.config[\"benchmarking\"][\"XCACHE_ATLAS_PREFIX\"],\n",
     ")\n",
     "\n",
     "print(f\"processes in fileset: {list(fileset.keys())}\")\n",

--- a/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.py
+++ b/analyses/cms-open-data-ttbar/ttbar_analysis_pipeline.py
@@ -374,7 +374,7 @@ fileset = utils.file_input.construct_fileset(
     use_xcache=False,
     af_name=utils.config["benchmarking"]["AF_NAME"],  # local files on /data for af_name="ssl-dev"
     input_from_eos=utils.config["benchmarking"]["INPUT_FROM_EOS"],
-    xcache_atlas_prefix=None,  # e.g. "root://xcache.af.uchicago.edu//" for UChicago
+    xcache_atlas_prefix=utils.config["benchmarking"]["XCACHE_ATLAS_PREFIX"],
 )
 
 print(f"processes in fileset: {list(fileset.keys())}")

--- a/analyses/cms-open-data-ttbar/utils/config.py
+++ b/analyses/cms-open-data-ttbar/utils/config.py
@@ -19,6 +19,9 @@ config = {
         # note that they are likely only available temporarily
         # and not part of an official CMS Open Data release
         "INPUT_FROM_EOS": False,
+        # prefix for URIs for ATLAS-style xcache use
+        # e.g. "root://xcache.af.uchicago.edu//" for UChicago
+        "XCACHE_ATLAS_PREFIX": None,
         ### metadata to propagate through to metrics ###
         # "ssl-dev" allows for the switch to local data on /data
         "AF_NAME": "coffea_casa",


### PR DESCRIPTION
This extends #189 to store the xcache prefix setting in the benchmarking config.