### PR TITLE
refactor: save available histograms and avoid hardcoding names

### DIFF
--- a/analyses/cms-open-data-ttbar/utils/file_output.py
+++ b/analyses/cms-open-data-ttbar/utils/file_output.py
@@ -1,46 +1,32 @@
 import uproot
 
 
-def save_histograms(hist_dict, fileset, filename, channel_names, add_offset=False):
-    nominal_samples = [sample for sample in fileset.keys() if "nominal" in sample]
-
+def save_histograms(hist_dict, filename, add_offset=False):
     with uproot.recreate(filename) as f:
-        out_dict = {}
-        for channel in channel_names:
-            current_hist = hist_dict[channel]
-
+        # save all available histograms to disk
+        for channel, histogram in hist_dict.items():
             # optionally add minimal offset to avoid completely empty bins
-            # (useful for the ML validation variables that would need binning adjustment to avoid those)
+            # (useful for the ML validation variables that would need binning adjustment
+            # to avoid those)
             if add_offset:
-                current_hist += 1e-6
+                histogram += 1e-6
 
-            out_dict[f"{channel}_pseudodata"] = ((current_hist[:, "ttbar", "ME_var"] + current_hist[:, "ttbar", "PS_var"]) / 2 
-                                                 + current_hist[:, "wjets", "nominal"])
+            for sample in histogram.axes[1]:
+                for variation in histogram[:, sample, :].axes[1]:
+                    variation_string = "" if variation == "nominal" else f"_{variation}"
+                    current_1d_hist = histogram[:, sample, variation]
 
-            for sample in nominal_samples:
-                sample_name = sample.split("__")[0]
-                out_dict[f"{channel}_{sample_name}"] = current_hist[:, sample_name, "nominal"]
+                    if sum(current_1d_hist.values()) != 0:
+                        # only save histograms containing events
+                        # many combinations are not used (e.g. ME var for W+jets)
+                        f[f"{channel}_{sample}{variation_string}"] = current_1d_hist
 
-                # b-tagging variations
-                for i in range(4):
-                    for direction in ["up", "down"]:
-                        variation_name = f"btag_var_{i}_{direction}"
-                        out_dict[f"{channel}_{sample_name}_{variation_name}"] = current_hist[:, sample_name, variation_name]
-
-                # jet energy scale variations
-                for variation_name in ["pt_scale_up", "pt_res_up"]:
-                    out_dict[f"{channel}_{sample_name}_{variation_name}"] = current_hist[:, sample_name, variation_name]
-
-            # ttbar modeling
-            ttbar_variations = ["ME_var", "PS_var", "scaleup", "scaledown"]
-            for var in ttbar_variations:
-                out_dict[f"{channel}_ttbar_{var}"] = current_hist[:, "ttbar", var]
-
-            # W+jets scale
-            wjets_variations = ["scale_var_down", "scale_var_up"]
-            for var in wjets_variations:
-                out_dict[f"{channel}_wjets_{var}"] = current_hist[:, "wjets", var]
-
-        # write to file
-        for key in out_dict.keys():
-            f[key] = out_dict[key]
+            # add pseudodata histogram if all inputs to it are available
+            if (
+                sum(histogram[:, "ttbar", "ME_var"]) != 0
+                and sum(histogram[:, "ttbar", "PS_var"]) != 0
+                and sum(histogram[:, "wjets", "nominal"]) != 0
+            ):
+                f[f"{channel}_pseudodata"] = (
+                    histogram[:, "ttbar", "ME_var"] + histogram[:, "ttbar", "PS_var"]
+                ) / 2 + histogram[:, "wjets", "nominal"]


### PR DESCRIPTION
To avoid hardcoding too much in the histogram saving function, instead look at what is contained in the histogram object and save everything that is found in the right format.