### PR TITLE
feat: add a client for Purdue Analysis Facility

### DIFF
--- a/analyses/cms-open-data-ttbar/utils/clients.py
+++ b/analyses/cms-open-data-ttbar/utils/clients.py
@@ -27,7 +27,18 @@ def get_client(af="coffea_casa"):
         cluster.scale(50)
         
         client = cluster.get_client()
-        
+
+    elif af == "purdue-af":
+        from dask_gateway import Gateway
+        gateway = Gateway(
+            "http://dask-gateway-k8s.geddes.rcac.purdue.edu/",
+            proxy_address="traefik-dask-gateway-k8s.cms.geddes.rcac.purdue.edu:8786",
+        )
+        clusters = gateway.list_clusters()
+        cluster = gateway.connect(clusters[0].name)
+        cluster.scale(10)        
+        client = cluster.get_client()
+
     elif af == "local":
         from dask.distributed import Client
 

--- a/analyses/cms-open-data-ttbar/utils/config.py
+++ b/analyses/cms-open-data-ttbar/utils/config.py
@@ -2,8 +2,9 @@ config = {
     "global": {
         # ServiceX: ignore cache with repeated queries
         "SERVICEX_IGNORE_CACHE": False,
-        # analysis facility: set to "coffea_casa" for coffea-casa environments, "EAF" for FNAL, "local" for local setups
-        "AF": "purdue-af",
+        # analysis facility: set to "coffea_casa" for coffea-casa environments,
+        # "EAF" for FNAL, "purdue-af" for Purdue Analysis Facility, "local" for local setups
+        "AF": "coffea_casa",
         # number of bins for standard histograms in processor
         "NUM_BINS": 25,
         # lower end of standard histograms in processor

--- a/analyses/cms-open-data-ttbar/utils/config.py
+++ b/analyses/cms-open-data-ttbar/utils/config.py
@@ -3,7 +3,7 @@ config = {
         # ServiceX: ignore cache with repeated queries
         "SERVICEX_IGNORE_CACHE": False,
         # analysis facility: set to "coffea_casa" for coffea-casa environments, "EAF" for FNAL, "local" for local setups
-        "AF": "coffea_casa",
+        "AF": "purdue-af",
         # number of bins for standard histograms in processor
         "NUM_BINS": 25,
         # lower end of standard histograms in processor


### PR DESCRIPTION
@oshadura @alexander-held following up on our chat last month:

This PR adds an option to run CMS OpenData workflow at Purdue Analysis Facility via Dask Gateway cluster.
The setup is similar to the `cmsaf-dev` option, the only differences are:

- The address of the Dask Gateway API server;
- The default number of workers is 10 to avoid using too much resources when running AGC as a "smoke test".

Additional info about the Dask Gateway setup at Purdue AF can be found [here](https://analysis-facility.physics.purdue.edu/en/latest/doc-dask-gateway.html). At Purdue AF, we have two Dask Gateway instances - with SLURM and Kubernetes backends. The `purdue-af` AGC client will use the Kubernetes backend.