### PR TITLE
feat: add support for REANA

### DIFF
--- a/analyses/cms-open-data-ttbar/reana.yaml
+++ b/analyses/cms-open-data-ttbar/reana.yaml
@@ -1,0 +1,30 @@
+inputs:
+  files:
+    - ttbar_analysis_pipeline.py
+    - nanoaod_inputs.json
+    - cabinetry_config.yml
+    - cabinetry_config_ml.yml
+    - corrections.json
+  directories:
+    - histograms
+    - utils
+    - models
+    - reference
+workflow:
+  type: serial
+  resources:
+    dask:
+      image: registry.cern.ch/docker.io/alputer/agc-dask:1.0.0
+      number_of_workers: 20
+      single_worker_memory: 2Gi
+      single_worker_threads: 1
+  specification:
+    steps:
+      - name: agc
+        environment: registry.cern.ch/docker.io/alputer/agc-dask:1.0.0
+        commands:
+          - python3 ttbar_analysis_pipeline.py
+outputs:
+  files:
+    - histograms.root
+    - workspace.json

--- a/analyses/cms-open-data-ttbar/utils/clients.py
+++ b/analyses/cms-open-data-ttbar/utils/clients.py
@@ -39,6 +39,13 @@ def get_client(af="coffea_casa"):
         cluster.scale(10)        
         client = cluster.get_client()
 
+    elif af == "reana":
+        import os
+        from dask.distributed import Client
+
+        DASK_SCHEDULER_URI = os.getenv("DASK_SCHEDULER_URI")
+        client = Client(DASK_SCHEDULER_URI)
+
     elif af == "local":
         from dask.distributed import Client
 

--- a/analyses/cms-open-data-ttbar/utils/config.py
+++ b/analyses/cms-open-data-ttbar/utils/config.py
@@ -5,7 +5,7 @@ config = {
         # ServiceX: set False to use remote data access
         "USE_SERVICEX_DOWNLOAD": False,
         # analysis facility: set to "coffea_casa" for coffea-casa environments,
-        # "EAF" for FNAL, "purdue-af" for Purdue Analysis Facility, "local" for local setups
+        # "EAF" for FNAL, "purdue-af" for Purdue Analysis Facility, "reana" for REANA, "local" for local setups
         "AF": "coffea_casa",
         # number of bins for standard histograms in processor
         "NUM_BINS": 25,


### PR DESCRIPTION
Add REANA as an alternative way to run the workflow with Dask. REANA brings up a dedicated Dask cluster for workflow and shuts it down after the workflow is finished.

* Note: Image is a patched version of `docker.io/coffeateam/coffea-base-almalinux9:head-py3.10`. Will be updated with an official image.
```Dockerfile
FROM docker.io/coffeateam/coffea-base-almalinux9:head-py3.10
RUN pip install cabinetry
RUN pip install --upgrade scikit-learn==1.5.2
```
